### PR TITLE
Enable algorithm selection for export

### DIFF
--- a/export_model.py
+++ b/export_model.py
@@ -1,14 +1,35 @@
 # export_model.py
 
+import argparse
 import joblib
-from train_model import build_and_train_pipeline
 
-def save_pipeline():
-    # Bouw en train de pipeline
-    pipeline = build_and_train_pipeline()
+from train_model import build_and_train_pipeline as build_rf
+from train_model_lgbm import build_and_train_pipeline as build_lgbm
+from train_model_xgb import build_and_train_pipeline as build_xgb
+
+def save_pipeline(algorithm: str = "rf"):
+    """Train en bewaar het pipeline-model voor het gekozen algoritme."""
+
+    if algorithm == "rf":
+        pipeline = build_rf()
+    elif algorithm == "lgbm":
+        pipeline = build_lgbm()
+    elif algorithm == "xgb":
+        pipeline = build_xgb()
+    else:
+        raise ValueError(f"Onbekend algoritme: {algorithm}")
+
     # Sla op
     joblib.dump(pipeline, 'f1_top3_pipeline.joblib')
     print("Pipeline opgeslagen als f1_top3_pipeline.joblib")
 
 if __name__ == '__main__':
-    save_pipeline()
+    parser = argparse.ArgumentParser(description="Exporteer een getrainde pipeline")
+    parser.add_argument(
+        "--algo",
+        choices=["rf", "lgbm", "xgb"],
+        default="rf",
+        help="Welk algoritme moet worden getraind en opgeslagen"
+    )
+    args = parser.parse_args()
+    save_pipeline(args.algo)

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -17,8 +17,16 @@ from sklearn.metrics import (
     mean_absolute_error,
 )
 
-def main(export_csv=True, csv_path="model_performance.csv"):
-    """Train een LightGBM-model en exporteer optioneel de resultaten."""
+def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
+    """Train een LightGBM-model en retourneer het beste model.
+
+    Parameters
+    ----------
+    export_csv : bool, optional
+        Of de evaluatiemetrics naar ``csv_path`` weggeschreven moeten worden.
+    csv_path : str, optional
+        Pad waar het CSV-bestand met prestaties wordt opgeslagen.
+    """
 
     # 1. Laad data
     df = pd.read_csv('processed_data.csv')
@@ -102,6 +110,12 @@ def main(export_csv=True, csv_path="model_performance.csv"):
         }).set_index('Metric')
         perf_df.to_csv(csv_path)
         print(f"Model performance saved to {csv_path}")
+
+    return grid.best_estimator_
+
+def main():
+    build_and_train_pipeline()
+
 
 if __name__ == '__main__':
     main()

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -18,8 +18,16 @@ from sklearn.metrics import (
 )
 
 
-def main(export_csv=True, csv_path="model_performance.csv"):
-    """Train een XGBoost-model en exporteer optioneel de resultaten."""
+def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
+    """Train een XGBoost-model en retourneer het beste model.
+
+    Parameters
+    ----------
+    export_csv : bool, optional
+        Of de evaluatiemetrics naar ``csv_path`` weggeschreven moeten worden.
+    csv_path : str, optional
+        Pad waar het CSV-bestand met prestaties wordt opgeslagen.
+    """
 
     # 1. Laad de verwerkte data
     df = pd.read_csv('processed_data.csv')
@@ -105,6 +113,12 @@ def main(export_csv=True, csv_path="model_performance.csv"):
         }).set_index('Metric')
         perf_df.to_csv(csv_path)
         print(f"Model performance saved to {csv_path}")
+
+    return grid.best_estimator_
+
+def main():
+    build_and_train_pipeline()
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- support selecting model algorithm in `export_model.py`
- return trained estimators from LGBM and XGB training scripts

## Testing
- `python -m py_compile export_model.py train_model.py train_model_lgbm.py train_model_xgb.py`
- `python export_model.py --algo lgbm` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_b_68457a486cec8331b330534e47864154