### PR TITLE
Add grid toggle and safety car filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ F1-Forecast is a small project that predicts which drivers will finish in the to
 | File | Purpose |
 | --- | --- |
 | `fetch_f1_data.py` | Download raw data from the OpenF1 and Jolpica APIs. Weather and session data come from OpenF1, while historical race and qualifying data come from Jolpica (an Ergast-compatible API). Functions `get_lap_data()`, `get_pitstop_data()`, `fetch_openf1_data()` and `fetch_jolpica_data()` all accept a `use_cache` flag. Lap and pit stop CSVs are cached under `cache/`, while the other helpers skip downloads if their output files already exist. |
-| `prepare_data.py` | Merge the downloaded CSV files into `processed_data.csv`. It engineers features such as qualifying times in seconds, rolling averages per driver and constructor, weather information and custom interaction features. |
+| `prepare_data.py` | Merge the downloaded CSV files into `processed_data.csv`. It engineers features such as qualifying times in seconds, rolling averages per driver and constructor, weather information and custom interaction features. Flags `--grid` and `--no-sc` control how overtakes are counted. |
 | `eda_f1.py` | Simple exploratory analysis on the raw CSV files. |
 | `train_model.py` | Train the main RandomForest pipeline using the processed data. Hyperparameters are tuned with `GridSearchCV`. |
 | `train_model_lgbm.py` | Alternative model using LightGBM. |
@@ -34,7 +34,7 @@ F1-Forecast is a small project that predicts which drivers will finish in the to
 
 2. **Prepare dataset**
    ```bash
-   python prepare_data.py
+   python prepare_data.py [--grid] [--no-sc]
    ```
    Creates `processed_data.csv` by merging qualifying, race results, circuit info, sessions and weather. Important steps:
    - Convert qualifying times to seconds (`Q1_sec`, `Q2_sec`, `Q3_sec`).
@@ -42,6 +42,8 @@ F1-Forecast is a small project that predicts which drivers will finish in the to
    - Compute rolling averages: previous finish position and grid position per driver, plus average constructor finish.
    - Merge weather via `session_key` and impute missing values.
    - Count on-track overtakes per driver using lap and pit stop data (`overtakes_count`).
+   - Optional `--grid` flag injects starting grid positions as lap 0 when counting overtakes (useful when lap 0 is missing).
+   - Optional `--no-sc` flag removes safety-car and virtual safety-car laps before computing overtakes.
    - Create interaction features: `grid_diff`, `Q3_diff`, `grid_temp_int`.
    The final CSV contains one row per driver per race with a boolean `top3` label. `prepare_data.py` also downloads lap time and pit stop data for each race using the cached helpers (`use_cache=True`).
 

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -1,28 +1,16 @@
 # prepare_data.py
 
+import argparse
 import pandas as pd
-from fetch_f1_data import get_lap_data, get_pitstop_data
-
-
-def compute_overtakes(valid_laps_df: pd.DataFrame) -> pd.DataFrame:
-    """Return overtakes_count per driver from valid (non-pit) laps."""
-    if valid_laps_df.empty:
-        return pd.DataFrame(columns=["driverId", "overtakes_count"])
-
-    valid_laps_df = valid_laps_df.sort_values(["driverId", "lap"])
-    valid_laps_df["prev_pos"] = (
-        valid_laps_df.groupby("driverId")["position"].shift(1)
-    )
-    valid_laps_df["overtake_flag"] = (
-        valid_laps_df["prev_pos"] == valid_laps_df["position"] + 1
-    ).astype(int)
-    overtake_counts = (
-        valid_laps_df.groupby("driverId")["overtake_flag"].sum().reset_index()
-    )
-    return overtake_counts.rename(columns={"overtake_flag": "overtakes_count"})
+from fetch_f1_data import get_lap_data, get_pitstop_data, compute_overtakes
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--grid', action='store_true', default=True)
+    parser.add_argument('--no-sc', dest='no_sc', action='store_true', default=False)
+    args = parser.parse_args()
+
     # 1. Bestandspaden
     files = {
         'qual':     'jolpica_qualifying.csv',
@@ -76,8 +64,14 @@ def main():
         pits = get_pitstop_data(season=season, round=rnd)
         if laps is None or laps.empty:
             continue
+        if args.no_sc:
+            laps = laps.query("statusId not in [3,4]")
         if pits is None:
             pits = pd.DataFrame(columns=["driverId", "lap"])
+
+        grid = df_qual[
+            (df_qual['season'] == season) & (df_qual['round'] == rnd)
+        ][['Driver.driverId', 'grid_position']].rename(columns={'Driver.driverId': 'driverId'})
 
         valid_laps = laps.merge(
             pits[['driverId', 'lap']],
@@ -86,7 +80,7 @@ def main():
             indicator=True
         )
         valid_laps = valid_laps.query("_merge=='left_only'").drop(columns=['_merge'])
-        overtakes = compute_overtakes(valid_laps)
+        overtakes = compute_overtakes(valid_laps, grid, include_grid=args.grid)
         overtakes['season'] = season
         overtakes['round'] = rnd
         over_frames.append(overtakes)


### PR DESCRIPTION
## Summary
- add optional grid inclusion in compute_overtakes
- expose compute_overtakes from fetch_f1_data
- allow filtering safety car laps in prepare_data
- add argparse CLI options `--grid` and `--no-sc`
- document new options in README

## Testing
- `python -m py_compile fetch_f1_data.py prepare_data.py eda_f1.py`


------
https://chatgpt.com/codex/tasks/task_b_684610dc0d0883319d2fe406131362a4