### PR TITLE
Add learning curve to training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ F1-Forecast is a small project that predicts which drivers will finish in the to
    - A `RandomForestClassifier` is tuned with a small parameter grid.
    - Metrics such as ROC‑AUC, precision/recall and mean absolute error are printed.
    - Key metrics are written to `model_performance.csv` for the Streamlit dashboard.
+   - A learning curve is calculated with `sklearn.model_selection.learning_curve` to check for over‑ or underfitting.
 
    You can experiment with other algorithms via `train_model_lgbm.py`, `train_model_xgb.py` or `train_model_nested_cv.py`. These scripts log their metrics to the same `model_performance.csv` file so the dashboard always shows the most recent training results.
 


### PR DESCRIPTION
## Summary
- compute a learning curve in `train_model.py` to detect over/underfitting
- mention learning curve step in README

## Testing
- `python -m py_compile train_model.py`

------
https://chatgpt.com/codex/tasks/task_b_6846a88528c88331b09c18c12edb3118