### PR TITLE
Remove overtake leakage features

### DIFF
--- a/infer.py
+++ b/infer.py
@@ -35,8 +35,7 @@ def inference_for_date(cutoff_date):
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
         'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
-        'circuit_country', 'circuit_city',
-        'overtakes_count', 'weighted_overtakes'
+        'circuit_country', 'circuit_city'
     ]
     X_test = df_test[feature_cols]
 

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -151,7 +151,19 @@ def main():
         on=['season', 'round', 'Driver.driverId'],
         how='left'
     )
+
+    # Use only past races for overtake features to avoid leakage
+    df = df.sort_values(['Driver.driverId', 'date'])
+    df['overtakes_count'] = (
+        df.groupby('Driver.driverId')['overtakes_count']
+          .shift()
+    )
+    df['weighted_overtakes'] = (
+        df.groupby('Driver.driverId')['weighted_overtakes']
+          .shift()
+    )
     df['overtakes_count'] = df['overtakes_count'].fillna(0)
+    df['weighted_overtakes'] = df['weighted_overtakes'].fillna(0)
 
     # 6. Doelvariabele
     df['finish_position'] = pd.to_numeric(df['finish_position'], errors='coerce')

--- a/train_model.py
+++ b/train_model.py
@@ -35,8 +35,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
         'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
-        'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
-        'overtakes_count', 'weighted_overtakes'
+        'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int'
     ]
     categorical_feats = ['circuit_country','circuit_city']
 

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -34,8 +34,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
         'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
-        'air_temperature', 'track_temperature',
-        'overtakes_count', 'weighted_overtakes'
+        'air_temperature', 'track_temperature'
     ]
     categorical_feats = ['circuit_country','circuit_city']
     X = df[numeric_feats + categorical_feats]

--- a/train_model_nested_cv.py
+++ b/train_model_nested_cv.py
@@ -17,8 +17,7 @@ def main(export_csv=True, csv_path="model_performance.csv"):
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
         'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
-        'air_temperature', 'track_temperature',
-        'overtakes_count', 'weighted_overtakes'
+        'air_temperature', 'track_temperature'
     ]
     categorical_feats = ['circuit_country','circuit_city']
     X = df[numeric_feats + categorical_feats]

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -35,8 +35,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
         'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
-        'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
-        'overtakes_count', 'weighted_overtakes'
+        'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int'
     ]
     categorical_feats = ['circuit_country','circuit_city']
 


### PR DESCRIPTION
## Summary
- ensure overtake stats only use past races
- drop overtake features from all training scripts
- keep inference feature list in sync

## Testing
- `python -m py_compile prepare_data.py train_model.py train_model_lgbm.py train_model_xgb.py train_model_nested_cv.py infer.py`

------
https://chatgpt.com/codex/tasks/task_b_6846d71235bc8331897052b2309f126b