### PR TITLE
Compute Q3 rolling average

### DIFF
--- a/prepare_data.py
+++ b/prepare_data.py
@@ -242,8 +242,11 @@ def main():
     # 14a. Grid-difference feature
     df['grid_diff'] = df['avg_grid_pos'] - df['grid_position']
 
-    # 14b. Q3-difference feature (eerst per driver avg Q3_sec berekenen)
-    driver_q3 = df.groupby('Driver.driverId')['Q3_sec'].transform('mean')
+    # 14b. Q3-difference feature op basis van voorgaande races
+    df = df.sort_values(['Driver.driverId', 'date'])
+    driver_q3 = df.groupby('Driver.driverId')['Q3_sec'].transform(
+        lambda s: s.shift().expanding().mean()
+    )
     df['Q3_diff'] = driver_q3 - df['Q3_sec']
 
     # 14c. Interaction grid × track temperature


### PR DESCRIPTION
## Summary
- make Q3_diff use prior races only

## Testing
- `python prepare_data.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python train_model.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python train_model_lgbm.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python train_model_xgb.py` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python train_model_nested_cv.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_6846dfb96e80833184635ccf44af61b4