### PR TITLE
Add group-based CV using races

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ F1-Forecast is a small project that predicts which drivers will finish in the to
    `circuit_country`, `circuit_city`.
    - Numerical features are median‑imputed and scaled; categorical features are one‑hot encoded.
    - A `RandomForestClassifier` is tuned with a small parameter grid.
-   - Cross‑validation uses `TimeSeriesSplit` so each fold only sees earlier races.
+   - Cross‑validation uses `GroupTimeSeriesSplit` so each fold only sees earlier races and keeps entire events together.
    - Metrics such as ROC‑AUC, confusion matrix, precision/recall and mean absolute error are printed.
    - Key metrics and the learning curve results are written to `model_performance.csv` for the Streamlit dashboard.
    - A learning curve is calculated with `sklearn.model_selection.learning_curve` to check for over‑ or underfitting.

--- a/train_model.py
+++ b/train_model.py
@@ -1,8 +1,32 @@
 # train_model.py
 
 import pandas as pd
-from sklearn.model_selection import TimeSeriesSplit, GridSearchCV, learning_curve
 import numpy as np
+try:
+    from sklearn.model_selection import GroupTimeSeriesSplit
+except ImportError:  # scikit-learn < 1.3
+    class GroupTimeSeriesSplit:
+        """Simple backport that keeps complete groups in each split."""
+
+        def __init__(self, n_splits: int = 5):
+            self.n_splits = n_splits
+
+        def split(self, X, y=None, groups=None):
+            if groups is None:
+                raise ValueError("The 'groups' parameter is required")
+            unique_groups = np.unique(groups)
+            n_groups = len(unique_groups)
+            test_size = n_groups // (self.n_splits + 1)
+            for i in range(self.n_splits):
+                train_end = test_size * (i + 1)
+                test_end = test_size * (i + 2)
+                train_groups = unique_groups[:train_end]
+                test_groups = unique_groups[train_end:test_end]
+                train_idx = np.where(np.isin(groups, train_groups))[0]
+                test_idx = np.where(np.isin(groups, test_groups))[0]
+                yield train_idx, test_idx
+
+from sklearn.model_selection import GridSearchCV, learning_curve
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.impute import SimpleImputer
@@ -32,6 +56,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     # 1. Laad de verwerkte data en sorteer chronologisch
     df = pd.read_csv('processed_data.csv', parse_dates=['date'])
     df = df.sort_values('date')
+    df['race_id'] = df['season'] * 100 + df['round']
 
     # 2. Definieer features & target
     numeric_feats = [
@@ -43,11 +68,18 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
 
     X = df[numeric_feats + categorical_feats]
     y = df['top3']
+    groups = df['race_id'].values
 
-    # 3. Tijdgebaseerde train/test-split (laatste 20% als test)
-    split_idx = int(len(df) * 0.8)
-    X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]
-    y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]
+    # 3. Tijdgebaseerde train/test-split (laatste 20% als test) op racebasis
+    unique_races = df['race_id'].drop_duplicates()
+    split_idx = int(len(unique_races) * 0.8)
+    train_races = unique_races.iloc[:split_idx]
+    test_races = unique_races.iloc[split_idx:]
+    train_mask = df['race_id'].isin(train_races)
+    test_mask = df['race_id'].isin(test_races)
+    X_train, X_test = X[train_mask], X[test_mask]
+    y_train, y_test = y[train_mask], y[test_mask]
+    train_groups = groups[train_mask]
 
     # 4. Preprocessing pipelines
     num_pipe = Pipeline([
@@ -79,19 +111,20 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
         'clf__max_features': ['sqrt', 'log2']
     }
 
-    # 7. GridSearchCV met time-series splits
-    cv = TimeSeriesSplit(n_splits=5)
+    # 7. GridSearchCV met groepsgebaseerde tijdsplits
+    cv = GroupTimeSeriesSplit(n_splits=5)
     grid = GridSearchCV(
         pipe, param_grid,
         scoring='roc_auc',
         cv=cv, n_jobs=-1, verbose=1
     )
-    grid.fit(X_train, y_train)
+    grid.fit(X_train, y_train, groups=train_groups)
 
     # 7b. Learning curve to detect over- or underfitting
     train_sizes, train_scores, val_scores = learning_curve(
         grid.best_estimator_, X, y,
-        cv=TimeSeriesSplit(n_splits=5), scoring='roc_auc',
+        groups=groups,
+        cv=GroupTimeSeriesSplit(n_splits=5), scoring='roc_auc',
         train_sizes=np.linspace(0.1, 1.0, 5), n_jobs=-1
     )
     train_mean = np.mean(train_scores, axis=1)

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -1,12 +1,32 @@
 # train_model_xgb.py
 
 import pandas as pd
+import numpy as np
+try:
+    from sklearn.model_selection import GroupTimeSeriesSplit
+except ImportError:  # scikit-learn < 1.3
+    class GroupTimeSeriesSplit:
+        def __init__(self, n_splits: int = 5):
+            self.n_splits = n_splits
+
+        def split(self, X, y=None, groups=None):
+            if groups is None:
+                raise ValueError("The 'groups' parameter is required")
+            unique_groups = np.unique(groups)
+            n_groups = len(unique_groups)
+            test_size = n_groups // (self.n_splits + 1)
+            for i in range(self.n_splits):
+                train_end = test_size * (i + 1)
+                test_end = test_size * (i + 2)
+                train_groups = unique_groups[:train_end]
+                test_groups = unique_groups[train_end:test_end]
+                train_idx = np.where(np.isin(groups, train_groups))[0]
+                test_idx = np.where(np.isin(groups, test_groups))[0]
+                yield train_idx, test_idx
 from sklearn.model_selection import (
-    TimeSeriesSplit,
     GridSearchCV,
     learning_curve,
 )
-import numpy as np
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.impute import SimpleImputer
@@ -38,6 +58,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     # 1. Laad de verwerkte data en sorteer chronologisch
     df = pd.read_csv('processed_data.csv', parse_dates=['date'])
     df = df.sort_values('date')
+    df['race_id'] = df['season'] * 100 + df['round']
 
     # 2. Definieer features en target
     numeric_feats = [
@@ -49,11 +70,18 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
 
     X = df[numeric_feats + categorical_feats]
     y = df['top3']
+    groups = df['race_id'].values
 
-    # 3. Tijdgebaseerde train/test-split (laatste 20% als test)
-    split_idx = int(len(df) * 0.8)
-    X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]
-    y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]
+    # 3. Tijdgebaseerde train/test-split (laatste 20% als test) op racebasis
+    unique_races = df['race_id'].drop_duplicates()
+    split_idx = int(len(unique_races) * 0.8)
+    train_races = unique_races.iloc[:split_idx]
+    test_races = unique_races.iloc[split_idx:]
+    train_mask = df['race_id'].isin(train_races)
+    test_mask = df['race_id'].isin(test_races)
+    X_train, X_test = X[train_mask], X[test_mask]
+    y_train, y_test = y[train_mask], y[test_mask]
+    train_groups = groups[train_mask]
 
     # 4. Preprocessing pipelines
     numeric_transformer = Pipeline([
@@ -88,8 +116,8 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
         'clf__reg_lambda': [1.0, 1.5]
     }
 
-    # 7. GridSearchCV met time-series splits
-    cv = TimeSeriesSplit(n_splits=5)
+    # 7. GridSearchCV met groepsgebaseerde tijdsplits
+    cv = GroupTimeSeriesSplit(n_splits=5)
     grid = GridSearchCV(
         estimator=pipe,
         param_grid=param_grid,
@@ -98,12 +126,13 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
         n_jobs=-1,
         verbose=2
     )
-    grid.fit(X_train, y_train)
+    grid.fit(X_train, y_train, groups=train_groups)
 
     # 7b. Learning curve to detect over- or underfitting
     train_sizes, train_scores, val_scores = learning_curve(
         grid.best_estimator_, X, y,
-        cv=TimeSeriesSplit(n_splits=5),
+        groups=groups,
+        cv=GroupTimeSeriesSplit(n_splits=5),
         scoring='roc_auc',
         train_sizes=np.linspace(0.1, 1.0, 5),
         n_jobs=-1,


### PR DESCRIPTION
## Summary
- implement `race_id` groups and use `GroupTimeSeriesSplit` across training scripts
- update docs to mention `GroupTimeSeriesSplit`

## Testing
- `python -m py_compile train_model.py train_model_lgbm.py train_model_xgb.py train_model_nested_cv.py`

------
https://chatgpt.com/codex/tasks/task_b_6846dfbb8268833197a85a965d2ba608