### PR TITLE
Add standings-based features

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ F1-Forecast is a small project that predicts which drivers will finish in the to
    - Convert qualifying times to seconds (`Q1_sec`, `Q2_sec`, `Q3_sec`).
    - Add date‑based features (`month`, `weekday`).
    - Compute rolling averages: previous finish position and grid position per driver, plus average constructor finish.
-   - Merge weather via `session_key` and impute missing values.
+  - Merge weather via `session_key` and impute missing values.
   - Count on-track overtakes per driver using lap and pit stop data
     (`overtakes_count`, `weighted_overtakes`). These columns are kept for
     analysis only and are no longer fed into the model.
+  - Parse driver and constructor standings to derive previous-season
+    points and rank (`driver_points_prev`, `driver_rank_prev`,
+    `constructor_points_prev`, `constructor_rank_prev`).
   - Create interaction features: `grid_diff`, `Q3_diff`, `grid_temp_int`.
    The final CSV contains one row per driver per race with a boolean `top3` label. `prepare_data.py` also downloads lap time and pit stop data for each race using the cached helpers (`use_cache=True`).
 
@@ -55,6 +58,8 @@ F1-Forecast is a small project that predicts which drivers will finish in the to
     `grid_position`, `Q1_sec`, `Q2_sec`, `Q3_sec`, `month`, `weekday`,
     `avg_finish_pos`, `avg_grid_pos`, `avg_const_finish`, `air_temperature`,
     `track_temperature`, `grid_diff`, `Q3_diff`, `grid_temp_int`,
+    `driver_points_prev`, `driver_rank_prev`,
+    `constructor_points_prev`, `constructor_rank_prev`,
    `circuit_country`, `circuit_city`.
    - Numerical features are median‑imputed and scaled; categorical features are one‑hot encoded.
    - A `RandomForestClassifier` is tuned with a small parameter grid.

--- a/infer.py
+++ b/infer.py
@@ -33,6 +33,22 @@ def inference_for_date(cutoff_date):
     )
     df['Q3_diff'] = df['driver_avg_Q3'] - df['Q3_sec']
     df['grid_temp_int'] = df['grid_position'] * df['track_temperature']
+    df['driver_points_prev'] = (
+        df.groupby('Driver.driverId')['driver_points']
+          .transform(lambda x: x.shift().expanding().mean())
+    )
+    df['driver_rank_prev'] = (
+        df.groupby('Driver.driverId')['driver_rank']
+          .transform(lambda x: x.shift().expanding().mean())
+    )
+    df['constructor_points_prev'] = (
+        df.groupby('constructorId')['constructor_points']
+          .transform(lambda x: x.shift().expanding().mean())
+    )
+    df['constructor_rank_prev'] = (
+        df.groupby('constructorId')['constructor_rank']
+          .transform(lambda x: x.shift().expanding().mean())
+    )
 
     # 5. Select only the rows of the cutoff_date for testing
     df_test = df[df['date'] == cutoff_date].copy()
@@ -45,6 +61,8 @@ def inference_for_date(cutoff_date):
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
         'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
+        'driver_points_prev', 'driver_rank_prev',
+        'constructor_points_prev', 'constructor_rank_prev',
         'circuit_country', 'circuit_city'
     ]
     X_test = df_test[feature_cols]

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -27,6 +27,14 @@ def prepare_features(df_sub):
                              .transform(lambda x: x.shift().expanding().mean())
     df_sub['Q3_diff']        = df_sub['driver_avg_Q3'] - df_sub['Q3_sec']
     df_sub['grid_temp_int']  = df_sub['grid_position'] * df_sub['track_temperature']
+    df_sub['driver_points_prev'] = df_sub.groupby('Driver.driverId')['driver_points']\
+                                   .transform(lambda x: x.shift().expanding().mean())
+    df_sub['driver_rank_prev'] = df_sub.groupby('Driver.driverId')['driver_rank']\
+                                  .transform(lambda x: x.shift().expanding().mean())
+    df_sub['constructor_points_prev'] = df_sub.groupby('constructorId')['constructor_points']\
+                                        .transform(lambda x: x.shift().expanding().mean())
+    df_sub['constructor_rank_prev'] = df_sub.groupby('constructorId')['constructor_rank']\
+                                       .transform(lambda x: x.shift().expanding().mean())
     return df_sub
 
 # Load data and pipeline with caching
@@ -59,6 +67,8 @@ feature_cols = [
     'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
     'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
     'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
+    'driver_points_prev', 'driver_rank_prev',
+    'constructor_points_prev', 'constructor_rank_prev',
     'circuit_country', 'circuit_city',
     'overtakes_count', 'weighted_overtakes'
 ]

--- a/train_model.py
+++ b/train_model.py
@@ -37,7 +37,9 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
         'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
-        'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int'
+        'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
+        'driver_points_prev', 'driver_rank_prev',
+        'constructor_points_prev', 'constructor_rank_prev'
     ]
     categorical_feats = ['circuit_country','circuit_city']
 

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -42,7 +42,9 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
         'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
-        'air_temperature', 'track_temperature'
+        'air_temperature', 'track_temperature',
+        'driver_points_prev', 'driver_rank_prev',
+        'constructor_points_prev', 'constructor_rank_prev'
     ]
     categorical_feats = ['circuit_country','circuit_city']
     X = df[numeric_feats + categorical_feats]

--- a/train_model_nested_cv.py
+++ b/train_model_nested_cv.py
@@ -18,7 +18,9 @@ def main(export_csv=True, csv_path="model_performance.csv"):
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
         'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
-        'air_temperature', 'track_temperature'
+        'air_temperature', 'track_temperature',
+        'driver_points_prev', 'driver_rank_prev',
+        'constructor_points_prev', 'constructor_rank_prev'
     ]
     categorical_feats = ['circuit_country','circuit_city']
     X = df[numeric_feats + categorical_feats]

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -43,7 +43,9 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
         'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
-        'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int'
+        'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
+        'driver_points_prev', 'driver_rank_prev',
+        'constructor_points_prev', 'constructor_rank_prev'
     ]
     categorical_feats = ['circuit_country','circuit_city']
 


### PR DESCRIPTION
## Summary
- parse driver & constructor standings
- compute driver/constructor points and ranks prior to each race
- include new rolling features in training, inference and Streamlit app
- document additional features in README

## Testing
- `python3 -m py_compile prepare_data.py train_model.py train_model_lgbm.py train_model_xgb.py train_model_nested_cv.py infer.py streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_b_6846dfbb82c88331b8156f0122b76cd4