### PR TITLE
Add CatBoost and LogisticRegression training support

### DIFF
--- a/export_model.py
+++ b/export_model.py
@@ -8,6 +8,8 @@ import pandas as pd
 from train_model import build_and_train_pipeline as build_rf
 from train_model_lgbm import build_and_train_pipeline as build_lgbm
 from train_model_xgb import build_and_train_pipeline as build_xgb
+from train_model_catboost import build_and_train_pipeline as build_catb
+from train_model_logreg import build_and_train_pipeline as build_logreg
 
 def save_pipeline(algorithm: str = "rf"):
     """Train en bewaar het pipeline-model voor het gekozen algoritme."""
@@ -18,6 +20,10 @@ def save_pipeline(algorithm: str = "rf"):
         pipeline, best_params = build_lgbm()
     elif algorithm == "xgb":
         pipeline, best_params = build_xgb()
+    elif algorithm == "catb":
+        pipeline, best_params = build_catb()
+    elif algorithm == "logreg":
+        pipeline, best_params = build_logreg()
     else:
         raise ValueError(f"Onbekend algoritme: {algorithm}")
 
@@ -38,7 +44,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Exporteer een getrainde pipeline")
     parser.add_argument(
         "--algo",
-        choices=["rf", "lgbm", "xgb"],
+        choices=["rf", "lgbm", "xgb", "catb", "logreg"],
         default="rf",
         help="Welk algoritme moet worden getraind en opgeslagen"
     )

--- a/train_model_logreg.py
+++ b/train_model_logreg.py
@@ -1,0 +1,142 @@
+# train_model_logreg.py
+
+import pandas as pd
+from sklearn.model_selection import TimeSeriesSplit, GridSearchCV, learning_curve
+import numpy as np
+from sklearn.compose import ColumnTransformer
+from sklearn.preprocessing import StandardScaler, OneHotEncoder
+from sklearn.impute import SimpleImputer
+from sklearn.pipeline import Pipeline
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import (
+    classification_report,
+    roc_auc_score,
+    confusion_matrix,
+    precision_recall_curve,
+    auc,
+    mean_absolute_error,
+)
+
+
+def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_performance.csv"):
+    """Train een LogisticRegression-model en retourneer het beste model en de hyperparameters."""
+
+    # 1. Laad en sorteer data
+    df = pd.read_csv('processed_data.csv', parse_dates=['date'])
+    df = df.sort_values('date')
+
+    # 2. Features
+    numeric_feats = [
+        'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
+        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int'
+    ]
+    categorical_feats = ['circuit_country', 'circuit_city']
+    X = df[numeric_feats + categorical_feats]
+    y = df['top3']
+
+    # 3. Train/test split
+    split_idx = int(len(df) * 0.8)
+    X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]
+    y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]
+
+    # 4. Preprocessing
+    num_pipe = Pipeline([
+        ('imputer', SimpleImputer(strategy='median')),
+        ('scaler', StandardScaler())
+    ])
+    cat_pipe = Pipeline([
+        ('imputer', SimpleImputer(strategy='constant', fill_value='missing')),
+        ('onehot', OneHotEncoder(handle_unknown='ignore'))
+    ])
+    preprocessor = ColumnTransformer([
+        ('num', num_pipe, numeric_feats),
+        ('cat', cat_pipe, categorical_feats)
+    ])
+
+    # 5. Pipeline met LogisticRegression
+    pipe = Pipeline([
+        ('pre', preprocessor),
+        ('clf', LogisticRegression(max_iter=1000, solver='lbfgs'))
+    ])
+
+    # 6. Hyperparameter grid
+    param_grid = {
+        'clf__C': [0.1, 1.0, 10.0],
+    }
+
+    # 7. GridSearchCV
+    cv = TimeSeriesSplit(n_splits=5)
+    grid = GridSearchCV(
+        pipe,
+        param_grid,
+        scoring='roc_auc',
+        cv=cv,
+        n_jobs=-1,
+        verbose=2,
+    )
+    grid.fit(X_train, y_train)
+
+    # 7b. Learning curve
+    train_sizes, train_scores, val_scores = learning_curve(
+        grid.best_estimator_, X, y,
+        cv=TimeSeriesSplit(n_splits=5),
+        scoring='roc_auc',
+        train_sizes=np.linspace(0.1, 1.0, 5),
+        n_jobs=-1,
+    )
+    train_mean = np.mean(train_scores, axis=1)
+    val_mean = np.mean(val_scores, axis=1)
+    print("\nLearning curve (ROC AUC):")
+    for sz, tr, val in zip(train_sizes, train_mean, val_mean):
+        print(f"  {int(sz)} samples -> train {tr:.3f}, val {val:.3f}")
+
+    # 8. Resultaten
+    print("=== Logistic Regression Best Params & CV ROC AUC ===")
+    print(grid.best_params_)
+    print(f"Best CV ROC AUC: {grid.best_score_:.3f}\n")
+
+    y_pred = grid.predict(X_test)
+    y_proba = grid.predict_proba(X_test)[:, 1]
+    print("=== Logistic Regression Test Performance ===")
+    print(classification_report(y_test, y_pred))
+    test_auc = roc_auc_score(y_test, y_proba)
+    print(f"Test ROC AUC: {test_auc:.3f}")
+
+    mae = mean_absolute_error(y_test, y_proba)
+    cm = confusion_matrix(y_test, y_pred)
+    print("\nConfusion Matrix:")
+    print(cm)
+    precision_vals, recall_vals, _ = precision_recall_curve(y_test, y_proba)
+    pr_auc = auc(recall_vals, precision_vals)
+
+    if export_csv:
+        base_metrics = {
+            'Metric': ['CV ROC AUC', 'Test ROC AUC', 'Mean Abs Error', 'PR AUC'],
+            'Value': [grid.best_score_, test_auc, mae, pr_auc],
+        }
+
+        lc_metrics = []
+        lc_values = []
+        for sz, tr, val in zip(train_sizes, train_mean, val_mean):
+            lc_metrics.append(f'LC {int(sz)} Train ROC AUC')
+            lc_values.append(tr)
+            lc_metrics.append(f'LC {int(sz)} Val ROC AUC')
+            lc_values.append(val)
+
+        all_metrics = base_metrics['Metric'] + lc_metrics
+        all_values = base_metrics['Value'] + lc_values
+
+        perf_df = pd.DataFrame({'Metric': all_metrics, 'Value': all_values}).set_index('Metric')
+        perf_df.to_csv(csv_path)
+        print(f"Model performance and learning curve saved to {csv_path}")
+
+    return grid.best_estimator_, grid.best_params_
+
+
+def main():
+    build_and_train_pipeline()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add CatBoost-based training script
- add optional Logistic Regression trainer
- extend `export_model.py` to recognize `catb` and `logreg` algorithms

## Testing
- `python -m py_compile train_model_catboost.py train_model_logreg.py export_model.py`

------
https://chatgpt.com/codex/tasks/task_b_6846dfbc8e90833195fd8648de53eac5