### PR TITLE
Fix GroupTimeSeriesSplit fallback

### DIFF
--- a/train_model.py
+++ b/train_model.py
@@ -26,6 +26,9 @@ except ImportError:  # scikit-learn < 1.3
                 test_idx = np.where(np.isin(groups, test_groups))[0]
                 yield train_idx, test_idx
 
+        def get_n_splits(self, X=None, y=None, groups=None):
+            return self.n_splits
+
 from sklearn.model_selection import GridSearchCV, learning_curve
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -23,6 +23,9 @@ except ImportError:  # scikit-learn < 1.3
                 train_idx = np.where(np.isin(groups, train_groups))[0]
                 test_idx = np.where(np.isin(groups, test_groups))[0]
                 yield train_idx, test_idx
+
+        def get_n_splits(self, X=None, y=None, groups=None):
+            return self.n_splits
 from sklearn.model_selection import (
     GridSearchCV,
     learning_curve,

--- a/train_model_logreg.py
+++ b/train_model_logreg.py
@@ -26,6 +26,9 @@ except ImportError:  # scikit-learn < 1.3
                 test_idx = np.where(np.isin(groups, test_groups))[0]
                 yield train_idx, test_idx
 
+        def get_n_splits(self, X=None, y=None, groups=None):
+            return self.n_splits
+
 from sklearn.model_selection import GridSearchCV, learning_curve
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder

--- a/train_model_nested_cv.py
+++ b/train_model_nested_cv.py
@@ -21,6 +21,9 @@ except ImportError:  # scikit-learn < 1.3
                 train_idx = np.where(np.isin(groups, train_groups))[0]
                 test_idx = np.where(np.isin(groups, test_groups))[0]
                 yield train_idx, test_idx
+
+        def get_n_splits(self, X=None, y=None, groups=None):
+            return self.n_splits
 from sklearn.model_selection import GridSearchCV, cross_val_score
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -23,6 +23,9 @@ except ImportError:  # scikit-learn < 1.3
                 train_idx = np.where(np.isin(groups, train_groups))[0]
                 test_idx = np.where(np.isin(groups, test_groups))[0]
                 yield train_idx, test_idx
+
+        def get_n_splits(self, X=None, y=None, groups=None):
+            return self.n_splits
 from sklearn.model_selection import (
     GridSearchCV,
     learning_curve,


### PR DESCRIPTION
## Summary
- fix fallback GroupTimeSeriesSplit class for scikit-learn<1.3

## Testing
- `python -m py_compile train_model.py train_model_lgbm.py train_model_xgb.py train_model_logreg.py train_model_nested_cv.py`


------
https://chatgpt.com/codex/tasks/task_b_6846d5f5ebdc8331aa89df950dfe6fe0