### PR TITLE
Fix nested cross-validation loops

### DIFF
--- a/train_model.py
+++ b/train_model.py
@@ -26,6 +26,9 @@ except ImportError:  # scikit-learn < 1.3
                 test_idx = np.where(np.isin(groups, test_groups))[0]
                 yield train_idx, test_idx
 
+        def get_n_splits(self, X=None, y=None, groups=None):
+            return self.n_splits
+
 from sklearn.model_selection import GridSearchCV, learning_curve
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -23,6 +23,9 @@ except ImportError:  # scikit-learn < 1.3
                 train_idx = np.where(np.isin(groups, train_groups))[0]
                 test_idx = np.where(np.isin(groups, test_groups))[0]
                 yield train_idx, test_idx
+
+        def get_n_splits(self, X=None, y=None, groups=None):
+            return self.n_splits
 from sklearn.model_selection import (
     GridSearchCV,
     learning_curve,

--- a/train_model_logreg.py
+++ b/train_model_logreg.py
@@ -26,6 +26,9 @@ except ImportError:  # scikit-learn < 1.3
                 test_idx = np.where(np.isin(groups, test_groups))[0]
                 yield train_idx, test_idx
 
+        def get_n_splits(self, X=None, y=None, groups=None):
+            return self.n_splits
+
 from sklearn.model_selection import GridSearchCV, learning_curve
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder

--- a/train_model_nested_cv.py
+++ b/train_model_nested_cv.py
@@ -21,7 +21,10 @@ except ImportError:  # scikit-learn < 1.3
                 train_idx = np.where(np.isin(groups, train_groups))[0]
                 test_idx = np.where(np.isin(groups, test_groups))[0]
                 yield train_idx, test_idx
-from sklearn.model_selection import GridSearchCV, cross_val_score
+
+        def get_n_splits(self, X=None, y=None, groups=None):
+            return self.n_splits
+from sklearn.model_selection import GridSearchCV
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.impute import SimpleImputer
@@ -87,16 +90,16 @@ def main(export_csv=True, csv_path="model_performance.csv"):
 
     # 5. Outer CV voor evaluatie met tijdreekssplits
     outer_cv = GroupTimeSeriesSplit(n_splits=5)
-    scores = cross_val_score(
-        grid,
-        X,
-        y,
-        groups=groups,
-        scoring='roc_auc',
-        cv=outer_cv,
-        n_jobs=-1,
-        fit_params={'groups': groups},
-    )
+    scores = []
+    for train_idx, test_idx in outer_cv.split(X, y, groups):
+        X_train, X_test = X.iloc[train_idx], X.iloc[test_idx]
+        y_train, y_test = y.iloc[train_idx], y.iloc[test_idx]
+        train_groups = groups[train_idx]
+        grid.fit(X_train, y_train, groups=train_groups)
+        y_pred = grid.predict_proba(X_test)[:, 1]
+        score = roc_auc_score(y_test, y_pred)
+        scores.append(score)
+    scores = np.array(scores)
     print("Nested CV ROC AUC scores:", scores)
     print("Mean & std:", scores.mean(), scores.std())
 

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -23,6 +23,9 @@ except ImportError:  # scikit-learn < 1.3
                 train_idx = np.where(np.isin(groups, train_groups))[0]
                 test_idx = np.where(np.isin(groups, test_groups))[0]
                 yield train_idx, test_idx
+
+        def get_n_splits(self, X=None, y=None, groups=None):
+            return self.n_splits
 from sklearn.model_selection import (
     GridSearchCV,
     learning_curve,


### PR DESCRIPTION
## Summary
- update GroupTimeSeriesSplit fallback in nested CV script
- avoid deprecated fit_params in `cross_val_score` by running outer loop manually

## Testing
- `python3 -m py_compile train_model.py train_model_lgbm.py train_model_xgb.py train_model_logreg.py train_model_nested_cv.py`


------
https://chatgpt.com/codex/tasks/task_b_6846d5f5ebdc8331aa89df950dfe6fe0