### PR TITLE
Use race-based CV in CatBoost training

### DIFF
--- a/train_model_catboost.py
+++ b/train_model_catboost.py
@@ -1,8 +1,35 @@
 # train_model_catboost.py
 
 import pandas as pd
-from sklearn.model_selection import TimeSeriesSplit, GridSearchCV, learning_curve
 import numpy as np
+try:
+    from sklearn.model_selection import GroupTimeSeriesSplit
+except ImportError:  # scikit-learn < 1.3
+    class GroupTimeSeriesSplit:
+        """Simple backport that keeps complete groups in each split."""
+
+        def __init__(self, n_splits: int = 5):
+            self.n_splits = n_splits
+
+        def split(self, X, y=None, groups=None):
+            if groups is None:
+                raise ValueError("The 'groups' parameter is required")
+            unique_groups = np.unique(groups)
+            n_groups = len(unique_groups)
+            test_size = n_groups // (self.n_splits + 1)
+            for i in range(self.n_splits):
+                train_end = test_size * (i + 1)
+                test_end = test_size * (i + 2)
+                train_groups = unique_groups[:train_end]
+                test_groups = unique_groups[train_end:test_end]
+                train_idx = np.where(np.isin(groups, train_groups))[0]
+                test_idx = np.where(np.isin(groups, test_groups))[0]
+                yield train_idx, test_idx
+
+        def get_n_splits(self, X=None, y=None, groups=None):
+            return self.n_splits
+
+from sklearn.model_selection import GridSearchCV, learning_curve
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.impute import SimpleImputer
@@ -24,6 +51,7 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
     # 1. Data laden
     df = pd.read_csv('processed_data.csv', parse_dates=['date'])
     df = df.sort_values('date')
+    df['race_id'] = df['season'] * 100 + df['round']
 
     # 2. Features en target
     numeric_feats = [
@@ -36,10 +64,17 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
     X = df[numeric_feats + categorical_feats]
     y = df['top3']
 
-    # 3. Tijdgebaseerde split
-    split_idx = int(len(df) * 0.8)
-    X_train, X_test = X.iloc[:split_idx], X.iloc[split_idx:]
-    y_train, y_test = y.iloc[:split_idx], y.iloc[split_idx:]
+    # 3. Tijdgebaseerde split op basis van unieke races
+    unique_races = df['race_id'].drop_duplicates()
+    split_idx = int(len(unique_races) * 0.8)
+    train_races = unique_races.iloc[:split_idx]
+    test_races = unique_races.iloc[split_idx:]
+    train_mask = df['race_id'].isin(train_races)
+    test_mask = df['race_id'].isin(test_races)
+    X_train, X_test = X[train_mask], X[test_mask]
+    y_train, y_test = y[train_mask], y[test_mask]
+    groups = df['race_id'].values
+    train_groups = groups[train_mask]
 
     # 4. Preprocessing
     num_pipe = Pipeline([
@@ -70,7 +105,7 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
     }
 
     # 7. GridSearchCV
-    cv = TimeSeriesSplit(n_splits=5)
+    cv = GroupTimeSeriesSplit(n_splits=5)
     grid = GridSearchCV(
         pipe,
         param_grid,
@@ -79,12 +114,13 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
         n_jobs=-1,
         verbose=2,
     )
-    grid.fit(X_train, y_train)
+    grid.fit(X_train, y_train, groups=train_groups)
 
     # 7b. Learning curve
     train_sizes, train_scores, val_scores = learning_curve(
         grid.best_estimator_, X, y,
-        cv=TimeSeriesSplit(n_splits=5),
+        groups=groups,
+        cv=GroupTimeSeriesSplit(n_splits=5),
         scoring='roc_auc',
         train_sizes=np.linspace(0.1, 1.0, 5),
         n_jobs=-1,


### PR DESCRIPTION
## Summary
- switch catboost training to a GroupTimeSeriesSplit
- split train/test sets by unique races with a `race_id`
- add fallback for `GroupTimeSeriesSplit`

## Testing
- `python -m py_compile train_model_catboost.py`

------
https://chatgpt.com/codex/tasks/task_b_6846fd03ffd08331ad39e4a55d6e406d