### PR TITLE
Support custom metrics files per algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ F1-Forecast is a small project that predicts which drivers will finish in the to
    - A `RandomForestClassifier` is tuned with a small parameter grid.
    - Cross‑validation uses `GroupTimeSeriesSplit` so each fold only sees earlier races and keeps entire events together.
    - Metrics such as ROC‑AUC, confusion matrix, precision/recall and mean absolute error are printed.
-   - Key metrics and the learning curve results are written to `model_performance.csv` for the Streamlit dashboard.
+   - Key metrics and the learning curve results are written to `model_performance_<algo>.csv` for the Streamlit dashboard.
    - A learning curve is calculated with `sklearn.model_selection.learning_curve` to check for over‑ or underfitting.
 
-   You can experiment with other algorithms via `train_model_lgbm.py`, `train_model_xgb.py` or `train_model_nested_cv.py`. These scripts output a confusion matrix and log their metrics—including learning curve values—to the same `model_performance.csv` file so the dashboard always shows the most recent training results.
+   You can experiment with other algorithms via `train_model_lgbm.py`, `train_model_xgb.py` or `train_model_nested_cv.py`. These scripts output a confusion matrix and log their metrics—including learning curve values—to a matching `model_performance_<algo>.csv` file so the dashboard always shows the most recent training results.
 
 4. **Export trained pipeline**
    ```bash

--- a/export_model.py
+++ b/export_model.py
@@ -14,16 +14,18 @@ from train_model_logreg import build_and_train_pipeline as build_logreg
 def save_pipeline(algorithm: str = "rf"):
     """Train en bewaar het pipeline-model voor het gekozen algoritme."""
 
+    metrics_csv = f"model_performance_{algorithm}.csv"
+
     if algorithm == "rf":
-        pipeline, best_params = build_rf()
+        pipeline, best_params = build_rf(csv_path=metrics_csv)
     elif algorithm == "lgbm":
-        pipeline, best_params = build_lgbm()
+        pipeline, best_params = build_lgbm(csv_path=metrics_csv)
     elif algorithm == "xgb":
-        pipeline, best_params = build_xgb()
+        pipeline, best_params = build_xgb(csv_path=metrics_csv)
     elif algorithm == "catb":
-        pipeline, best_params = build_catb()
+        pipeline, best_params = build_catb(csv_path=metrics_csv)
     elif algorithm == "logreg":
-        pipeline, best_params = build_logreg()
+        pipeline, best_params = build_logreg(csv_path=metrics_csv)
     else:
         raise ValueError(f"Onbekend algoritme: {algorithm}")
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -47,6 +47,31 @@ def load_pipeline():
 df = load_data()
 pipeline = load_pipeline()
 
+
+def detect_algorithm(pipe):
+    name = pipe.named_steps['clf'].__class__.__name__.lower()
+    if 'xgb' in name:
+        return 'xgb'
+    if 'lgbm' in name:
+        return 'lgbm'
+    if 'catboost' in name:
+        return 'catboost'
+    if 'logistic' in name:
+        return 'logreg'
+    return 'rf'
+
+
+algo = detect_algorithm(pipeline)
+metrics_path = f"model_performance_{algo}.csv"
+try:
+    perf_df = pd.read_csv(metrics_path, index_col='Metric')
+except FileNotFoundError:
+    perf_df = None
+
+if perf_df is not None:
+    st.sidebar.subheader("Training metrics")
+    st.sidebar.dataframe(perf_df)
+
 # Sidebar for season and race selection
 seasons = sorted(df['season'].unique())
 selected_season = st.sidebar.selectbox('Selecteer seizoen', seasons, index=len(seasons)-1)

--- a/train_model_catboost.py
+++ b/train_model_catboost.py
@@ -1,5 +1,6 @@
 # train_model_catboost.py
 
+import argparse
 import pandas as pd
 import numpy as np
 try:
@@ -45,7 +46,10 @@ from sklearn.metrics import (
 )
 
 
-def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_performance.csv"):
+def build_and_train_pipeline(
+    export_csv: bool = True,
+    csv_path: str = "model_performance_catboost.csv",
+):
     """Train een CatBoost-model en retourneer het beste model en de hyperparameters."""
 
     # 1. Data laden
@@ -190,7 +194,14 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
 
 
 def main():
-    build_and_train_pipeline()
+    parser = argparse.ArgumentParser(description="Train CatBoost model")
+    parser.add_argument(
+        "--csv",
+        default="model_performance_catboost.csv",
+        help="Output CSV file for metrics",
+    )
+    args = parser.parse_args()
+    build_and_train_pipeline(csv_path=args.csv)
 
 
 if __name__ == '__main__':

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -1,5 +1,6 @@
 # train_model_lgbm.py
 
+import argparse
 import pandas as pd
 import numpy as np
 try:
@@ -45,7 +46,10 @@ from sklearn.metrics import (
     mean_absolute_error,
 )
 
-def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
+def build_and_train_pipeline(
+    export_csv=True,
+    csv_path="model_performance_lgbm.csv",
+):
     """Train een LightGBM-model en retourneer het beste model en de bijbehorende
     hyperparameters.
 
@@ -201,7 +205,14 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     return grid.best_estimator_, grid.best_params_
 
 def main():
-    build_and_train_pipeline()
+    parser = argparse.ArgumentParser(description="Train LightGBM model")
+    parser.add_argument(
+        "--csv",
+        default="model_performance_lgbm.csv",
+        help="Output CSV file for metrics",
+    )
+    args = parser.parse_args()
+    build_and_train_pipeline(csv_path=args.csv)
 
 
 if __name__ == '__main__':

--- a/train_model_logreg.py
+++ b/train_model_logreg.py
@@ -1,5 +1,6 @@
 # train_model_logreg.py
 
+import argparse
 import pandas as pd
 import numpy as np
 try:
@@ -45,7 +46,10 @@ from sklearn.metrics import (
 )
 
 
-def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_performance.csv"):
+def build_and_train_pipeline(
+    export_csv: bool = True,
+    csv_path: str = "model_performance_logreg.csv",
+):
     """Train een LogisticRegression-model en retourneer het beste model en de hyperparameters."""
 
     # 1. Laad en sorteer data
@@ -182,7 +186,14 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
 
 
 def main():
-    build_and_train_pipeline()
+    parser = argparse.ArgumentParser(description="Train logistic regression model")
+    parser.add_argument(
+        "--csv",
+        default="model_performance_logreg.csv",
+        help="Output CSV file for metrics",
+    )
+    args = parser.parse_args()
+    build_and_train_pipeline(csv_path=args.csv)
 
 
 if __name__ == '__main__':

--- a/train_model_nested_cv.py
+++ b/train_model_nested_cv.py
@@ -1,3 +1,4 @@
+import argparse
 import pandas as pd
 import numpy as np
 try:
@@ -34,7 +35,7 @@ from sklearn.metrics import (
     roc_auc_score,
 )
 
-def main(export_csv=True, csv_path="model_performance.csv"):
+def main(export_csv=True, csv_path="model_performance_nested.csv"):
     """Voert nested cross-validation uit en exporteert optioneel de resultaten."""
 
     # 1. Data laden en sorteren op datum
@@ -121,4 +122,11 @@ def main(export_csv=True, csv_path="model_performance.csv"):
         print(f"Model performance saved to {csv_path}")
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser(description="Run nested cross-validation")
+    parser.add_argument(
+        "--csv",
+        default="model_performance_nested.csv",
+        help="Output CSV file for metrics",
+    )
+    args = parser.parse_args()
+    main(csv_path=args.csv)

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -1,5 +1,6 @@
 # train_model_xgb.py
 
+import argparse
 import pandas as pd
 import numpy as np
 try:
@@ -46,7 +47,10 @@ from sklearn.metrics import (
 )
 
 
-def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
+def build_and_train_pipeline(
+    export_csv=True,
+    csv_path="model_performance_xgb.csv",
+):
     """Train een XGBoost-model en retourneer het beste model samen met de
     optimale hyperparameters.
 
@@ -203,7 +207,14 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     return grid.best_estimator_, grid.best_params_
 
 def main():
-    build_and_train_pipeline()
+    parser = argparse.ArgumentParser(description="Train XGBoost model")
+    parser.add_argument(
+        "--csv",
+        default="model_performance_xgb.csv",
+        help="Output CSV file for metrics",
+    )
+    args = parser.parse_args()
+    build_and_train_pipeline(csv_path=args.csv)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- parameterize output CSV path for all `train_model_*` scripts
- pass algorithm-specific metrics path from `export_model.py`
- show training metrics in Streamlit sidebar
- document per-algorithm metrics files in README

## Testing
- `python -m py_compile train_model_catboost.py train_model_lgbm.py train_model_xgb.py train_model_logreg.py train_model_nested_cv.py export_model.py streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_b_6847f86198308331be2f800b0adaafd0