### PR TITLE
Add home race and track type features

### DIFF
--- a/backtest_time_series.py
+++ b/backtest_time_series.py
@@ -15,9 +15,10 @@ df = df.sort_values('date')
 numeric_feats = [
     'grid_position','Q1_sec','Q2_sec','Q3_sec',
     'month','weekday','avg_finish_pos','avg_grid_pos','avg_const_finish',
-    'air_temperature','track_temperature','grid_diff','Q3_diff','grid_temp_int'
+    'air_temperature','track_temperature','grid_diff','Q3_diff','grid_temp_int',
+    'driver_home_race','rank_diff'
 ]
-categorical_feats = ['circuit_country','circuit_city']
+categorical_feats = ['circuit_country','circuit_city','track_type']
 feature_cols = numeric_feats + categorical_feats
 
 # 3) Preprocessing pipeline

--- a/feature_importance.py
+++ b/feature_importance.py
@@ -8,7 +8,8 @@ FEATURE_COLS = [
     'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
     'driver_points_prev', 'driver_rank_prev',
     'constructor_points_prev', 'constructor_rank_prev',
-    'circuit_country', 'circuit_city',
+    'driver_home_race', 'rank_diff',
+    'circuit_country', 'circuit_city', 'track_type',
 ]
 
 

--- a/infer.py
+++ b/infer.py
@@ -63,7 +63,8 @@ def inference_for_date(cutoff_date):
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',
-        'circuit_country', 'circuit_city',
+        'driver_home_race', 'rank_diff',
+        'circuit_country', 'circuit_city', 'track_type',
         # Overtakes-features
         'overtakes_count',             # absolute aantal inhaalacties vorige races
         'weighted_overtakes',          # gewogen aantal inhaalacties

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -181,6 +181,9 @@ def main():
     ]
     df[prev_cols] = df[prev_cols].fillna(df[prev_cols].median())
 
+    # Difference between driver and constructor ranks
+    df['rank_diff'] = df['driver_rank_prev'] - df['constructor_rank_prev']
+
     # --- Overtakes per race -------------------------------------------------
     over_frames = []
     for season, rnd in df_results[['season', 'round']].drop_duplicates().itertuples(index=False):
@@ -268,6 +271,24 @@ def main():
         'Location.lat':'circuit_lat', 'Location.long':'circuit_long',
         'Location.locality':'circuit_city', 'Location.country':'circuit_country'
     })
+
+    # Indicator whether the driver races in their home country
+    df['driver_home_race'] = (
+        df['Driver.nationality'] == df['circuit_country']
+    ).astype(int)
+
+    # Map circuits to track type (street vs permanent)
+    track_type_map = {
+        'albert_park': 'street',
+        'baku': 'street',
+        'jeddah': 'street',
+        'marina_bay': 'street',
+        'miami': 'street',
+        'monaco': 'street',
+        'vegas': 'street',
+        'villeneuve': 'street'
+    }
+    df['track_type'] = df['circuitId'].map(track_type_map).fillna('permanent')
 
     # 11. Rolling averages per driver
     df = df.sort_values(['Driver.driverId','date'])

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -65,7 +65,8 @@ feature_cols = [
     'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
     'driver_points_prev', 'driver_rank_prev',
     'constructor_points_prev', 'constructor_rank_prev',
-    'circuit_country', 'circuit_city',
+    'driver_home_race', 'rank_diff',
+    'circuit_country', 'circuit_city', 'track_type',
         # Overtakes-features
     'overtakes_count',             # absolute aantal inhaalacties vorige races
     'weighted_overtakes',          # gewogen aantal inhaalacties

--- a/train_model.py
+++ b/train_model.py
@@ -68,6 +68,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',
+        'driver_home_race', 'rank_diff',
 
         # Overtakes-features
         'overtakes_count',             # absolute aantal inhaalacties vorige races
@@ -77,7 +78,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
         'ewma_overtakes_per_lap',
         'ewma_weighted_overtakes_per_lap'
     ]
-    categorical_feats = ['circuit_country','circuit_city']
+    categorical_feats = ['circuit_country','circuit_city','track_type']
 
     X = df[numeric_feats + categorical_feats]
     y = df['top3']

--- a/train_model_catboost.py
+++ b/train_model_catboost.py
@@ -60,6 +60,7 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
         'air_temperature', 'track_temperature',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',
+        'driver_home_race', 'rank_diff',
 
         # Overtakes-features
         'overtakes_count',             # absolute aantal inhaalacties vorige races
@@ -69,7 +70,7 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
         'ewma_overtakes_per_lap',
         'ewma_weighted_overtakes_per_lap'
     ]
-    categorical_feats = ['circuit_country', 'circuit_city']
+    categorical_feats = ['circuit_country', 'circuit_city', 'track_type']
 
     X = df[numeric_feats + categorical_feats]
     y = df['top3']

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -69,6 +69,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
         'air_temperature', 'track_temperature',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',
+        'driver_home_race', 'rank_diff',
 
         # Overtakes-features
         'overtakes_count',             # absolute aantal inhaalacties vorige races
@@ -78,7 +79,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
         'ewma_overtakes_per_lap',
         'ewma_weighted_overtakes_per_lap'
     ]
-    categorical_feats = ['circuit_country','circuit_city']
+    categorical_feats = ['circuit_country','circuit_city','track_type']
     X = df[numeric_feats + categorical_feats]
     y = df['top3']
     groups = df['race_id'].values

--- a/train_model_logreg.py
+++ b/train_model_logreg.py
@@ -59,6 +59,7 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',
+        'driver_home_race', 'rank_diff',
 
         # Overtakes-features
         'overtakes_count',             # absolute aantal inhaalacties vorige races
@@ -68,7 +69,7 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
         'ewma_overtakes_per_lap',
         'ewma_weighted_overtakes_per_lap'
     ]
-    categorical_feats = ['circuit_country', 'circuit_city']
+    categorical_feats = ['circuit_country', 'circuit_city', 'track_type']
     df['race_id'] = df['season'] * 100 + df['round']
     X = df[numeric_feats + categorical_feats]
     y = df['top3']

--- a/train_model_nested_cv.py
+++ b/train_model_nested_cv.py
@@ -47,6 +47,7 @@ def main(export_csv=True, csv_path="model_performance.csv"):
         'air_temperature', 'track_temperature',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',
+        'driver_home_race', 'rank_diff',
 
         # Overtakes-features
         'overtakes_count',             # absolute aantal inhaalacties vorige races
@@ -56,7 +57,7 @@ def main(export_csv=True, csv_path="model_performance.csv"):
         'ewma_overtakes_per_lap',
         'ewma_weighted_overtakes_per_lap'
     ]
-    categorical_feats = ['circuit_country','circuit_city']
+    categorical_feats = ['circuit_country','circuit_city','track_type']
     X = df[numeric_feats + categorical_feats]
     y = df['top3']
     groups = df['race_id'].values

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -70,6 +70,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',
+        'driver_home_race', 'rank_diff',
 
         # Overtakes-features
         'overtakes_count',             # absolute aantal inhaalacties vorige races
@@ -79,7 +80,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
         'ewma_overtakes_per_lap',
         'ewma_weighted_overtakes_per_lap'
     ]
-    categorical_feats = ['circuit_country','circuit_city']
+    categorical_feats = ['circuit_country','circuit_city','track_type']
 
     X = df[numeric_feats + categorical_feats]
     y = df['top3']


### PR DESCRIPTION
## Summary
- add driver home race and circuit track type features
- calculate difference in driver vs constructor ranking
- include new columns in model training scripts

## Testing
- `python -m py_compile prepare_data.py train_model.py train_model_lgbm.py train_model_logreg.py train_model_catboost.py train_model_xgb.py train_model_nested_cv.py backtest_time_series.py feature_importance.py streamlit_app.py infer.py`

------
https://chatgpt.com/codex/tasks/task_b_6847f86036c883319ec44929cec082ad