### PR TITLE
Add validation splits with early stopping

### DIFF
--- a/train_model_catboost.py
+++ b/train_model_catboost.py
@@ -46,7 +46,8 @@ from sklearn.metrics import (
 
 
 def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_performance.csv"):
-    """Train een CatBoost-model en retourneer het beste model en de hyperparameters."""
+    """Train een CatBoost-model en retourneer het beste model, de
+    hyperparameters en de best gevonden iteratie."""
 
     # 1. Data laden
     df = pd.read_csv('processed_data.csv', parse_dates=['date'])
@@ -81,10 +82,17 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
     test_races = unique_races.iloc[split_idx:]
     train_mask = df['race_id'].isin(train_races)
     test_mask = df['race_id'].isin(test_races)
-    X_train, X_test = X[train_mask], X[test_mask]
-    y_train, y_test = y[train_mask], y[test_mask]
+    X_train_full, X_test = X[train_mask], X[test_mask]
+    y_train_full, y_test = y[train_mask], y[test_mask]
     groups = df['race_id'].values
-    train_groups = groups[train_mask]
+    groups_full = groups[train_mask]
+
+    # 3b. Validation split binnen training met GroupTimeSeriesSplit
+    gts = GroupTimeSeriesSplit(n_splits=5)
+    train_idx, val_idx = list(gts.split(X_train_full, y_train_full, groups=groups_full))[-1]
+    X_train, X_val = X_train_full.iloc[train_idx], X_train_full.iloc[val_idx]
+    y_train, y_val = y_train_full.iloc[train_idx], y_train_full.iloc[val_idx]
+    train_groups = groups_full[train_idx]
 
     # 4. Preprocessing
     num_pipe = Pipeline([
@@ -129,7 +137,15 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
         n_jobs=-1,
         verbose=2,
     )
-    grid.fit(X_train, y_train, groups=train_groups)
+    grid.fit(
+        X_train,
+        y_train,
+        groups=train_groups,
+        clf__eval_set=[(X_val, y_val)],
+        clf__early_stopping_rounds=50,
+        clf__verbose=False,
+    )
+    best_iter = grid.best_estimator_.named_steps['clf'].get_best_iteration()
 
     # 7b. Learning curve
     train_sizes, train_scores, val_scores = learning_curve(
@@ -149,7 +165,8 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
     # 8. Resultaten
     print("=== CatBoost Best Params & CV ROC AUC ===")
     print(grid.best_params_)
-    print(f"Best CV ROC AUC: {grid.best_score_:.3f}\n")
+    print(f"Best CV ROC AUC: {grid.best_score_:.3f}")
+    print(f"Best Iteration: {best_iter}\n")
 
     y_pred = grid.predict(X_test)
     y_proba = grid.predict_proba(X_test)[:, 1]
@@ -167,8 +184,14 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
 
     if export_csv:
         base_metrics = {
-            'Metric': ['CV ROC AUC', 'Test ROC AUC', 'Mean Abs Error', 'PR AUC'],
-            'Value': [grid.best_score_, test_auc, mae, pr_auc],
+            'Metric': [
+                'CV ROC AUC',
+                'Test ROC AUC',
+                'Mean Abs Error',
+                'PR AUC',
+                'Best Iteration',
+            ],
+            'Value': [grid.best_score_, test_auc, mae, pr_auc, best_iter],
         }
 
         lc_metrics = []
@@ -186,7 +209,7 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
         perf_df.to_csv(csv_path)
         print(f"Model performance and learning curve saved to {csv_path}")
 
-    return grid.best_estimator_, grid.best_params_
+    return grid.best_estimator_, grid.best_params_, best_iter
 
 
 def main():

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -46,8 +46,8 @@ from sklearn.metrics import (
 )
 
 def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
-    """Train een LightGBM-model en retourneer het beste model en de bijbehorende
-    hyperparameters.
+    """Train een LightGBM-model en retourneer het beste model, de
+    hyperparameters en de best gevonden iteratie.
 
     Parameters
     ----------
@@ -90,9 +90,16 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     test_races = unique_races.iloc[split_idx:]
     train_mask = df['race_id'].isin(train_races)
     test_mask = df['race_id'].isin(test_races)
-    X_train, X_test = X[train_mask], X[test_mask]
-    y_train, y_test = y[train_mask], y[test_mask]
-    train_groups = groups[train_mask]
+    X_train_full, X_test = X[train_mask], X[test_mask]
+    y_train_full, y_test = y[train_mask], y[test_mask]
+    groups_full = groups[train_mask]
+
+    # 3b. Validation split binnen training met GroupTimeSeriesSplit
+    gts = GroupTimeSeriesSplit(n_splits=5)
+    train_idx, val_idx = list(gts.split(X_train_full, y_train_full, groups=groups_full))[-1]
+    X_train, X_val = X_train_full.iloc[train_idx], X_train_full.iloc[val_idx]
+    y_train, y_val = y_train_full.iloc[train_idx], y_train_full.iloc[val_idx]
+    train_groups = groups_full[train_idx]
 
     # 4. Preprocessing
     numeric_transformer = Pipeline([
@@ -140,7 +147,15 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
         n_jobs=-1,
         verbose=2
     )
-    grid.fit(X_train, y_train, groups=train_groups)
+    grid.fit(
+        X_train,
+        y_train,
+        groups=train_groups,
+        clf__eval_set=[(X_val, y_val)],
+        clf__early_stopping_rounds=50,
+        clf__verbose=False,
+    )
+    best_iter = grid.best_estimator_.named_steps['clf'].best_iteration_
 
     # 7b. Learning curve to detect over- or underfitting
     train_sizes, train_scores, val_scores = learning_curve(
@@ -160,7 +175,8 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     # 8. Output beste resultaat
     print("=== LightGBM Best Params & CV ROC AUC ===")
     print(grid.best_params_)
-    print(f"CV ROC AUC: {grid.best_score_:.3f}\n")
+    print(f"CV ROC AUC: {grid.best_score_:.3f}")
+    print(f"Best Iteration: {best_iter}\n")
 
     # 9. Testset evaluatie
     y_pred  = grid.predict(X_test)
@@ -179,8 +195,14 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
 
     if export_csv:
         base_metrics = {
-            'Metric': ['CV ROC AUC', 'Test ROC AUC', 'Mean Abs Error', 'PR AUC'],
-            'Value': [grid.best_score_, test_auc, mae, pr_auc],
+            'Metric': [
+                'CV ROC AUC',
+                'Test ROC AUC',
+                'Mean Abs Error',
+                'PR AUC',
+                'Best Iteration',
+            ],
+            'Value': [grid.best_score_, test_auc, mae, pr_auc, best_iter],
         }
 
         lc_metrics = []
@@ -198,7 +220,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
         perf_df.to_csv(csv_path)
         print(f"Model performance and learning curve saved to {csv_path}")
 
-    return grid.best_estimator_, grid.best_params_
+    return grid.best_estimator_, grid.best_params_, best_iter
 
 def main():
     build_and_train_pipeline()


### PR DESCRIPTION
## Summary
- create validation splits in LightGBM, XGBoost and CatBoost training scripts
- enable early stopping during fitting
- export best iteration number with metrics

## Testing
- `python -m py_compile train_model_lgbm.py train_model_xgb.py train_model_catboost.py`

------
https://chatgpt.com/codex/tasks/task_b_6847f85f232c83319eaf8a03f7392fb1