### PR TITLE
Fix early stopping params

### DIFF
--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -36,6 +36,7 @@ from sklearn.preprocessing import StandardScaler, OneHotEncoder
 from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
 from lightgbm import LGBMClassifier
+import lightgbm as lgb
 from sklearn.metrics import (
     classification_report,
     roc_auc_score,
@@ -159,8 +160,9 @@ def build_and_train_pipeline(
         y_train,
         groups=train_groups,
         clf__eval_set=[(X_val, y_val)],
-        clf__early_stopping_rounds=50,
-        clf__verbose=False,
+        clf__callbacks=[
+            lgb.early_stopping(50, verbose=False),
+        ],
     )
     best_iter = grid.best_estimator_.named_steps['clf'].best_iteration_
 

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -146,6 +146,8 @@ def build_and_train_pipeline(
 
     # 7. GridSearchCV met groepsgebaseerde tijdsplits
     cv = GroupTimeSeriesSplit(n_splits=5)
+    # zet early stopping rondes op het model zelf
+    pipe.set_params(clf__early_stopping_rounds=50)
     grid = GridSearchCV(
         estimator=pipe,
         param_grid=param_grid,
@@ -159,7 +161,6 @@ def build_and_train_pipeline(
         y_train,
         groups=train_groups,
         clf__eval_set=[(X_val, y_val)],
-        clf__early_stopping_rounds=50,
         clf__verbose=False,
     )
     best_iter = grid.best_estimator_.named_steps['clf'].best_iteration


### PR DESCRIPTION
## Summary
- update LightGBM training to use callback-based early stopping
- set early stopping on XGBoost estimator instead of passing as fit param

## Testing
- `python train_model_lgbm.py --csv temp.csv` *(fails: interrupted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_b_6847f723808883318669c3cb5666d0fd