### PR TITLE
Add early stopping with validation fold

### DIFF
--- a/train_model_catboost.py
+++ b/train_model_catboost.py
@@ -81,10 +81,18 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
     test_races = unique_races.iloc[split_idx:]
     train_mask = df['race_id'].isin(train_races)
     test_mask = df['race_id'].isin(test_races)
-    X_train, X_test = X[train_mask], X[test_mask]
-    y_train, y_test = y[train_mask], y[test_mask]
+    X_train_full, X_test = X[train_mask], X[test_mask]
+    y_train_full, y_test = y[train_mask], y[test_mask]
     groups = df['race_id'].values
-    train_groups = groups[train_mask]
+    groups_train_full = groups[train_mask]
+
+    # Laatste fold van GroupTimeSeriesSplit als validatie
+    gts = GroupTimeSeriesSplit(n_splits=5)
+    splits = list(gts.split(X_train_full, y_train_full, groups=groups_train_full))
+    train_idx, val_idx = splits[-1]
+    X_train, X_val = X_train_full.iloc[train_idx], X_train_full.iloc[val_idx]
+    y_train, y_val = y_train_full.iloc[train_idx], y_train_full.iloc[val_idx]
+    train_groups = groups_train_full[train_idx]
 
     # 4. Preprocessing
     num_pipe = Pipeline([
@@ -120,7 +128,7 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
     }
 
     # 7. GridSearchCV
-    cv = GroupTimeSeriesSplit(n_splits=5)
+    cv = GroupTimeSeriesSplit(n_splits=4)
     grid = GridSearchCV(
         pipe,
         param_grid,
@@ -129,7 +137,14 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
         n_jobs=-1,
         verbose=2,
     )
-    grid.fit(X_train, y_train, groups=train_groups)
+    grid.fit(
+        X_train,
+        y_train,
+        groups=train_groups,
+        clf__eval_set=[(X_val, y_val)],
+        clf__early_stopping_rounds=50,
+        clf__verbose=False,
+    )
 
     # 7b. Learning curve
     train_sizes, train_scores, val_scores = learning_curve(
@@ -186,7 +201,12 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
         perf_df.to_csv(csv_path)
         print(f"Model performance and learning curve saved to {csv_path}")
 
-    return grid.best_estimator_, grid.best_params_
+    best_iter = None
+    if hasattr(grid.best_estimator_.named_steps['clf'], 'get_best_iteration'):
+        best_iter = grid.best_estimator_.named_steps['clf'].get_best_iteration()
+    else:
+        best_iter = getattr(grid.best_estimator_.named_steps['clf'], 'best_iteration_', None)
+    return grid.best_estimator_, grid.best_params_, best_iter
 
 
 def main():

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -90,9 +90,17 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     test_races = unique_races.iloc[split_idx:]
     train_mask = df['race_id'].isin(train_races)
     test_mask = df['race_id'].isin(test_races)
-    X_train, X_test = X[train_mask], X[test_mask]
-    y_train, y_test = y[train_mask], y[test_mask]
-    train_groups = groups[train_mask]
+    X_train_full, X_test = X[train_mask], X[test_mask]
+    y_train_full, y_test = y[train_mask], y[test_mask]
+    groups_train_full = groups[train_mask]
+
+    # Laatste fold van GroupTimeSeriesSplit als validatieset
+    gts = GroupTimeSeriesSplit(n_splits=5)
+    splits = list(gts.split(X_train_full, y_train_full, groups=groups_train_full))
+    train_idx, val_idx = splits[-1]
+    X_train, X_val = X_train_full.iloc[train_idx], X_train_full.iloc[val_idx]
+    y_train, y_val = y_train_full.iloc[train_idx], y_train_full.iloc[val_idx]
+    train_groups = groups_train_full[train_idx]
 
     # 4. Preprocessing
     numeric_transformer = Pipeline([
@@ -131,7 +139,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     }
 
     # 7. GridSearchCV met groepsgebaseerde tijdsplits
-    cv = GroupTimeSeriesSplit(n_splits=5)
+    cv = GroupTimeSeriesSplit(n_splits=4)
     grid = GridSearchCV(
         estimator=pipe,
         param_grid=param_grid,
@@ -140,7 +148,14 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
         n_jobs=-1,
         verbose=2
     )
-    grid.fit(X_train, y_train, groups=train_groups)
+    grid.fit(
+        X_train,
+        y_train,
+        groups=train_groups,
+        clf__eval_set=[(X_val, y_val)],
+        clf__early_stopping_rounds=50,
+        clf__verbose=False,
+    )
 
     # 7b. Learning curve to detect over- or underfitting
     train_sizes, train_scores, val_scores = learning_curve(
@@ -198,7 +213,8 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
         perf_df.to_csv(csv_path)
         print(f"Model performance and learning curve saved to {csv_path}")
 
-    return grid.best_estimator_, grid.best_params_
+    best_iter = getattr(grid.best_estimator_.named_steps['clf'], 'best_iteration_', None)
+    return grid.best_estimator_, grid.best_params_, best_iter
 
 def main():
     build_and_train_pipeline()


### PR DESCRIPTION
## Summary
- hold out the last fold of each training split for validation
- enable early stopping for LightGBM, CatBoost and XGBoost models
- return the best iteration from the training scripts
- use the recorded best iteration when exporting the final model

## Testing
- `python -m py_compile train_model_lgbm.py train_model_catboost.py train_model_xgb.py export_model.py`

------
https://chatgpt.com/codex/tasks/task_b_68482a3aad5c833194ba990cd9d094e5