### PR TITLE
Add cyclical date features

### DIFF
--- a/infer.py
+++ b/infer.py
@@ -59,7 +59,8 @@ def inference_for_date(cutoff_date):
     # 7. Feature columns exactly as trained
     feature_cols = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'month_sin', 'month_cos', 'weekday_sin', 'weekday_cos',
+        'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -1,6 +1,7 @@
 # prepare_data.py
 
 import pandas as pd
+import numpy as np
 import ast
 from fetch_f1_data import get_lap_data, get_pitstop_data
 
@@ -245,6 +246,10 @@ def main():
     df['date']    = pd.to_datetime(df['date'])
     df['month']   = df['date'].dt.month
     df['weekday'] = df['date'].dt.weekday
+    df['month_sin']   = np.sin(2 * np.pi * df['month'] / 12)
+    df['month_cos']   = np.cos(2 * np.pi * df['month'] / 12)
+    df['weekday_sin'] = np.sin(2 * np.pi * df['weekday'] / 7)
+    df['weekday_cos'] = np.cos(2 * np.pi * df['weekday'] / 7)
 
     # 9. Impute kwalificatietijden per circuit
     # Sorteer op datum zodat we circuit-medians alleen uit voorgaande races

--- a/train_model.py
+++ b/train_model.py
@@ -64,7 +64,8 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     # 2. Definieer features & target
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'month_sin', 'month_cos', 'weekday_sin', 'weekday_cos',
+        'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',

--- a/train_model_catboost.py
+++ b/train_model_catboost.py
@@ -56,7 +56,8 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
     # 2. Features en target
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'month_sin', 'month_cos', 'weekday_sin', 'weekday_cos',
+        'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -65,7 +65,8 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     # 2. Features & target
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'month_sin', 'month_cos', 'weekday_sin', 'weekday_cos',
+        'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',

--- a/train_model_logreg.py
+++ b/train_model_logreg.py
@@ -55,7 +55,8 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
     # 2. Features
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'month_sin', 'month_cos', 'weekday_sin', 'weekday_cos',
+        'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',

--- a/train_model_nested_cv.py
+++ b/train_model_nested_cv.py
@@ -43,7 +43,8 @@ def main(export_csv=True, csv_path="model_performance.csv"):
     df['race_id'] = df['season'] * 100 + df['round']
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'month_sin', 'month_cos', 'weekday_sin', 'weekday_cos',
+        'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -66,7 +66,8 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     # 2. Definieer features en target
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'month_sin', 'month_cos', 'weekday_sin', 'weekday_cos',
+        'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',


### PR DESCRIPTION
## Summary
- compute month_sin/cos and weekday_sin/cos in `prepare_data.py`
- train all models with new cyclical features
- update inference feature list to match

## Testing
- `python -m py_compile prepare_data.py train_model.py train_model_catboost.py train_model_lgbm.py train_model_logreg.py train_model_nested_cv.py train_model_xgb.py infer.py`

------
https://chatgpt.com/codex/tasks/task_b_68482a1151748331b6f49353b5159854