### PR TITLE
Add driver age feature to dataset and models

### DIFF
--- a/backtest_time_series.py
+++ b/backtest_time_series.py
@@ -14,7 +14,7 @@ df = df.sort_values('date')
 # 2) Feature‐lijst
 numeric_feats = [
     'grid_position','Q1_sec','Q2_sec','Q3_sec',
-    'month','weekday','avg_finish_pos','avg_grid_pos','avg_const_finish',
+    'month','weekday','driver_age','avg_finish_pos','avg_grid_pos','avg_const_finish',
     'air_temperature','track_temperature','grid_diff','Q3_diff','grid_temp_int'
 ]
 categorical_feats = ['circuit_country','circuit_city']

--- a/infer.py
+++ b/infer.py
@@ -59,7 +59,7 @@ def inference_for_date(cutoff_date):
     # 7. Feature columns exactly as trained
     feature_cols = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'driver_age', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -243,6 +243,9 @@ def main():
 
     # 8. Datum invoeren
     df['date']    = pd.to_datetime(df['date'])
+    df['driver_age'] = (
+        df['date'] - pd.to_datetime(df['Driver.dateOfBirth'])
+    ).dt.days / 365.25
     df['month']   = df['date'].dt.month
     df['weekday'] = df['date'].dt.weekday
 

--- a/train_model.py
+++ b/train_model.py
@@ -64,7 +64,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     # 2. Definieer features & target
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'driver_age', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',

--- a/train_model_catboost.py
+++ b/train_model_catboost.py
@@ -56,7 +56,7 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
     # 2. Features en target
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'driver_age', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -65,7 +65,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     # 2. Features & target
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'driver_age', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',

--- a/train_model_logreg.py
+++ b/train_model_logreg.py
@@ -55,7 +55,7 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_per
     # 2. Features
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'driver_age', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',

--- a/train_model_nested_cv.py
+++ b/train_model_nested_cv.py
@@ -43,7 +43,7 @@ def main(export_csv=True, csv_path="model_performance.csv"):
     df['race_id'] = df['season'] * 100 + df['round']
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'driver_age', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -66,7 +66,7 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     # 2. Definieer features en target
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'weekday', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
+        'month', 'weekday', 'driver_age', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'air_temperature', 'track_temperature', 'grid_diff', 'Q3_diff', 'grid_temp_int',
         'driver_points_prev', 'driver_rank_prev',
         'constructor_points_prev', 'constructor_rank_prev',


### PR DESCRIPTION
## Summary
- compute `driver_age` in `prepare_data.py`
- include `driver_age` feature in all training and inference scripts

## Testing
- `python -m py_compile prepare_data.py train_model.py train_model_catboost.py train_model_lgbm.py train_model_logreg.py train_model_xgb.py train_model_nested_cv.py backtest_time_series.py infer.py`

------
https://chatgpt.com/codex/tasks/task_b_68482a2a849483319af8c4e25e73c948