### PR TITLE
Refactor GroupTimeSeriesSplit into shared module

### DIFF
--- a/train_model.py
+++ b/train_model.py
@@ -2,32 +2,7 @@
 
 import pandas as pd
 import numpy as np
-try:
-    from sklearn.model_selection import GroupTimeSeriesSplit
-except ImportError:  # scikit-learn < 1.3
-    class GroupTimeSeriesSplit:
-        """Simple backport that keeps complete groups in each split."""
-
-        def __init__(self, n_splits: int = 5):
-            self.n_splits = n_splits
-
-        def split(self, X, y=None, groups=None):
-            if groups is None:
-                raise ValueError("The 'groups' parameter is required")
-            unique_groups = np.unique(groups)
-            n_groups = len(unique_groups)
-            test_size = n_groups // (self.n_splits + 1)
-            for i in range(self.n_splits):
-                train_end = test_size * (i + 1)
-                test_end = test_size * (i + 2)
-                train_groups = unique_groups[:train_end]
-                test_groups = unique_groups[train_end:test_end]
-                train_idx = np.where(np.isin(groups, train_groups))[0]
-                test_idx = np.where(np.isin(groups, test_groups))[0]
-                yield train_idx, test_idx
-
-        def get_n_splits(self, X=None, y=None, groups=None):
-            return self.n_splits
+from utils.time_series import GroupTimeSeriesSplit
 
 from sklearn.model_selection import GridSearchCV, learning_curve
 from sklearn.compose import ColumnTransformer

--- a/train_model_catboost.py
+++ b/train_model_catboost.py
@@ -2,32 +2,7 @@
 
 import pandas as pd
 import numpy as np
-try:
-    from sklearn.model_selection import GroupTimeSeriesSplit
-except ImportError:  # scikit-learn < 1.3
-    class GroupTimeSeriesSplit:
-        """Simple backport that keeps complete groups in each split."""
-
-        def __init__(self, n_splits: int = 5):
-            self.n_splits = n_splits
-
-        def split(self, X, y=None, groups=None):
-            if groups is None:
-                raise ValueError("The 'groups' parameter is required")
-            unique_groups = np.unique(groups)
-            n_groups = len(unique_groups)
-            test_size = n_groups // (self.n_splits + 1)
-            for i in range(self.n_splits):
-                train_end = test_size * (i + 1)
-                test_end = test_size * (i + 2)
-                train_groups = unique_groups[:train_end]
-                test_groups = unique_groups[train_end:test_end]
-                train_idx = np.where(np.isin(groups, train_groups))[0]
-                test_idx = np.where(np.isin(groups, test_groups))[0]
-                yield train_idx, test_idx
-
-        def get_n_splits(self, X=None, y=None, groups=None):
-            return self.n_splits
+from utils.time_series import GroupTimeSeriesSplit
 
 from sklearn.model_selection import GridSearchCV, learning_curve
 from sklearn.compose import ColumnTransformer

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -2,30 +2,7 @@
 
 import pandas as pd
 import numpy as np
-try:
-    from sklearn.model_selection import GroupTimeSeriesSplit
-except ImportError:  # scikit-learn < 1.3
-    class GroupTimeSeriesSplit:
-        def __init__(self, n_splits: int = 5):
-            self.n_splits = n_splits
-
-        def split(self, X, y=None, groups=None):
-            if groups is None:
-                raise ValueError("The 'groups' parameter is required")
-            unique_groups = np.unique(groups)
-            n_groups = len(unique_groups)
-            test_size = n_groups // (self.n_splits + 1)
-            for i in range(self.n_splits):
-                train_end = test_size * (i + 1)
-                test_end = test_size * (i + 2)
-                train_groups = unique_groups[:train_end]
-                test_groups = unique_groups[train_end:test_end]
-                train_idx = np.where(np.isin(groups, train_groups))[0]
-                test_idx = np.where(np.isin(groups, test_groups))[0]
-                yield train_idx, test_idx
-
-        def get_n_splits(self, X=None, y=None, groups=None):
-            return self.n_splits
+from utils.time_series import GroupTimeSeriesSplit
 from sklearn.model_selection import (
     GridSearchCV,
     learning_curve,

--- a/train_model_logreg.py
+++ b/train_model_logreg.py
@@ -2,32 +2,7 @@
 
 import pandas as pd
 import numpy as np
-try:
-    from sklearn.model_selection import GroupTimeSeriesSplit
-except ImportError:  # scikit-learn < 1.3
-    class GroupTimeSeriesSplit:
-        """Simple backport that keeps complete groups in each split."""
-
-        def __init__(self, n_splits: int = 5):
-            self.n_splits = n_splits
-
-        def split(self, X, y=None, groups=None):
-            if groups is None:
-                raise ValueError("The 'groups' parameter is required")
-            unique_groups = np.unique(groups)
-            n_groups = len(unique_groups)
-            test_size = n_groups // (self.n_splits + 1)
-            for i in range(self.n_splits):
-                train_end = test_size * (i + 1)
-                test_end = test_size * (i + 2)
-                train_groups = unique_groups[:train_end]
-                test_groups = unique_groups[train_end:test_end]
-                train_idx = np.where(np.isin(groups, train_groups))[0]
-                test_idx = np.where(np.isin(groups, test_groups))[0]
-                yield train_idx, test_idx
-
-        def get_n_splits(self, X=None, y=None, groups=None):
-            return self.n_splits
+from utils.time_series import GroupTimeSeriesSplit
 
 from sklearn.model_selection import GridSearchCV, learning_curve
 from sklearn.compose import ColumnTransformer

--- a/train_model_nested_cv.py
+++ b/train_model_nested_cv.py
@@ -1,29 +1,6 @@
 import pandas as pd
 import numpy as np
-try:
-    from sklearn.model_selection import GroupTimeSeriesSplit
-except ImportError:  # scikit-learn < 1.3
-    class GroupTimeSeriesSplit:
-        def __init__(self, n_splits: int = 5):
-            self.n_splits = n_splits
-
-        def split(self, X, y=None, groups=None):
-            if groups is None:
-                raise ValueError("The 'groups' parameter is required")
-            unique_groups = np.unique(groups)
-            n_groups = len(unique_groups)
-            test_size = n_groups // (self.n_splits + 1)
-            for i in range(self.n_splits):
-                train_end = test_size * (i + 1)
-                test_end = test_size * (i + 2)
-                train_groups = unique_groups[:train_end]
-                test_groups = unique_groups[train_end:test_end]
-                train_idx = np.where(np.isin(groups, train_groups))[0]
-                test_idx = np.where(np.isin(groups, test_groups))[0]
-                yield train_idx, test_idx
-
-        def get_n_splits(self, X=None, y=None, groups=None):
-            return self.n_splits
+from utils.time_series import GroupTimeSeriesSplit
 from sklearn.model_selection import GridSearchCV
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder

--- a/train_model_stacking.py
+++ b/train_model_stacking.py
@@ -13,32 +13,7 @@ compared easily.
 
 import pandas as pd
 import numpy as np
-try:
-    from sklearn.model_selection import GroupTimeSeriesSplit
-except ImportError:  # scikit-learn < 1.3
-    class GroupTimeSeriesSplit:
-        """Simple backport that keeps complete groups in each split."""
-
-        def __init__(self, n_splits: int = 5):
-            self.n_splits = n_splits
-
-        def split(self, X, y=None, groups=None):
-            if groups is None:
-                raise ValueError("The 'groups' parameter is required")
-            unique_groups = np.unique(groups)
-            n_groups = len(unique_groups)
-            test_size = n_groups // (self.n_splits + 1)
-            for i in range(self.n_splits):
-                train_end = test_size * (i + 1)
-                test_end = test_size * (i + 2)
-                train_groups = unique_groups[:train_end]
-                test_groups = unique_groups[train_end:test_end]
-                train_idx = np.where(np.isin(groups, train_groups))[0]
-                test_idx = np.where(np.isin(groups, test_groups))[0]
-                yield train_idx, test_idx
-
-        def get_n_splits(self, X=None, y=None, groups=None):
-            return self.n_splits
+from utils.time_series import GroupTimeSeriesSplit
 
 from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import StandardScaler, OneHotEncoder

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -2,30 +2,7 @@
 
 import pandas as pd
 import numpy as np
-try:
-    from sklearn.model_selection import GroupTimeSeriesSplit
-except ImportError:  # scikit-learn < 1.3
-    class GroupTimeSeriesSplit:
-        def __init__(self, n_splits: int = 5):
-            self.n_splits = n_splits
-
-        def split(self, X, y=None, groups=None):
-            if groups is None:
-                raise ValueError("The 'groups' parameter is required")
-            unique_groups = np.unique(groups)
-            n_groups = len(unique_groups)
-            test_size = n_groups // (self.n_splits + 1)
-            for i in range(self.n_splits):
-                train_end = test_size * (i + 1)
-                test_end = test_size * (i + 2)
-                train_groups = unique_groups[:train_end]
-                test_groups = unique_groups[train_end:test_end]
-                train_idx = np.where(np.isin(groups, train_groups))[0]
-                test_idx = np.where(np.isin(groups, test_groups))[0]
-                yield train_idx, test_idx
-
-        def get_n_splits(self, X=None, y=None, groups=None):
-            return self.n_splits
+from utils.time_series import GroupTimeSeriesSplit
 from sklearn.model_selection import (
     GridSearchCV,
     learning_curve,

--- a/utils/time_series.py
+++ b/utils/time_series.py
@@ -1,0 +1,32 @@
+"""Utility functions and classes for time series cross-validation."""
+
+import numpy as np
+
+try:
+    from sklearn.model_selection import GroupTimeSeriesSplit
+except ImportError:  # scikit-learn < 1.3
+    class GroupTimeSeriesSplit:
+        """Simple backport that keeps complete groups in each split."""
+
+        def __init__(self, n_splits: int = 5):
+            self.n_splits = n_splits
+
+        def split(self, X, y=None, groups=None):
+            if groups is None:
+                raise ValueError("The 'groups' parameter is required")
+            unique_groups = np.unique(groups)
+            n_groups = len(unique_groups)
+            test_size = n_groups // (self.n_splits + 1)
+            for i in range(self.n_splits):
+                train_end = test_size * (i + 1)
+                test_end = test_size * (i + 2)
+                train_groups = unique_groups[:train_end]
+                test_groups = unique_groups[train_end:test_end]
+                train_idx = np.where(np.isin(groups, train_groups))[0]
+                test_idx = np.where(np.isin(groups, test_groups))[0]
+                yield train_idx, test_idx
+
+        def get_n_splits(self, X=None, y=None, groups=None):
+            return self.n_splits
+
+__all__ = ["GroupTimeSeriesSplit"]


### PR DESCRIPTION
## Summary
- add `utils.time_series` with a backport of `GroupTimeSeriesSplit`
- use the shared class in all training and stacking scripts
- remove duplicate implementations

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68486d37484c83318716c1d60574162e