### PR TITLE
Write model metrics to dedicated csv files

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ F1-Forecast is a small project that predicts which drivers will finish in the to
    - A `RandomForestClassifier` is tuned with a small parameter grid.
    - Cross‑validation uses `GroupTimeSeriesSplit` so each fold only sees earlier races and keeps entire events together.
    - Metrics such as ROC‑AUC, confusion matrix, precision/recall and mean absolute error are printed.
-   - Key metrics and the learning curve results are written to `model_performance.csv` for the Streamlit dashboard.
+   - Key metrics and the learning curve results are written to a dedicated CSV
+     file (e.g. `rf_model_performance.csv`) so each algorithm keeps its own
+     results for the Streamlit dashboard.
    - A learning curve is calculated with `sklearn.model_selection.learning_curve` to check for over‑ or underfitting.
 
-   You can experiment with other algorithms via `train_model_lgbm.py`, `train_model_xgb.py`, `train_model_catboost.py`, `train_model_logreg.py`, `train_model_stacking.py` or `train_model_nested_cv.py`. These scripts output a confusion matrix and log their metrics—including learning curve values—to the same `model_performance.csv` file so the dashboard always shows the most recent training results.
+   You can experiment with other algorithms via `train_model_lgbm.py`, `train_model_xgb.py`, `train_model_catboost.py`, `train_model_logreg.py`, `train_model_stacking.py` or `train_model_nested_cv.py`. Each of these scripts now writes its metrics to a separate file like `lgbm_model_performance.csv` or `xgb_model_performance.csv`, keeping results isolated while still allowing the dashboard to read the latest run per algorithm.
 
 4. **Export trained pipeline**
    ```bash

--- a/train_model.py
+++ b/train_model.py
@@ -19,7 +19,7 @@ from sklearn.metrics import (
     mean_absolute_error,
 )
 
-def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
+def build_and_train_pipeline(export_csv=True, csv_path="rf_model_performance.csv"):
     """Bouwt de pipeline, traint hem en retourneert het beste model en de
     corresponderende hyperparameters.
 
@@ -28,7 +28,9 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     export_csv : bool, optional
         Of de evaluatiemetrics naar ``csv_path`` weggeschreven moeten worden.
     csv_path : str, optional
-        Pad waar het CSV-bestand met prestaties wordt opgeslagen.
+        Pad waar het CSV-bestand met prestaties wordt opgeslagen. Standaard
+        wordt dit ``rf_model_performance.csv`` zodat elke trainingsscript
+        zijn eigen resultaten bijhoudt.
     """
 
     # 1. Laad de verwerkte data en sorteer chronologisch

--- a/train_model_catboost.py
+++ b/train_model_catboost.py
@@ -20,8 +20,17 @@ from sklearn.metrics import (
 )
 
 
-def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_performance.csv"):
-    """Train een CatBoost-model en retourneer het beste model en de hyperparameters."""
+def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "catboost_model_performance.csv"):
+    """Train een CatBoost-model en retourneer het beste model en de hyperparameters.
+
+    Parameters
+    ----------
+    export_csv : bool, optional
+        Of de evaluatiemetrics naar ``csv_path`` weggeschreven moeten worden.
+    csv_path : str, optional
+        Pad waar de resultaten terechtkomen. Standaard ``catboost_model_performance.csv``
+        zodat elke trainingsscript een eigen bestand gebruikt.
+    """
 
     # 1. Data laden
     df = pd.read_csv('processed_data.csv', parse_dates=['date'])

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -22,7 +22,7 @@ from sklearn.metrics import (
     mean_absolute_error,
 )
 
-def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
+def build_and_train_pipeline(export_csv=True, csv_path="lgbm_model_performance.csv"):
     """Train een LightGBM-model en retourneer het beste model en de bijbehorende
     hyperparameters.
 
@@ -31,7 +31,9 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     export_csv : bool, optional
         Of de evaluatiemetrics naar ``csv_path`` weggeschreven moeten worden.
     csv_path : str, optional
-        Pad waar het CSV-bestand met prestaties wordt opgeslagen.
+        Pad waar het CSV-bestand met prestaties wordt opgeslagen. Standaard
+        wordt dit ``lgbm_model_performance.csv`` zodat iedere algoritme een
+        eigen bestand heeft.
     """
 
     # 1. Laad data en sorteer chronologisch

--- a/train_model_logreg.py
+++ b/train_model_logreg.py
@@ -20,8 +20,17 @@ from sklearn.metrics import (
 )
 
 
-def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "model_performance.csv"):
-    """Train een LogisticRegression-model en retourneer het beste model en de hyperparameters."""
+def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "logreg_model_performance.csv"):
+    """Train een LogisticRegression-model en retourneer het beste model en de hyperparameters.
+
+    Parameters
+    ----------
+    export_csv : bool, optional
+        Of de evaluatiemetrics naar ``csv_path`` weggeschreven moeten worden.
+    csv_path : str, optional
+        Pad waar de resultaten worden opgeslagen. Standaard ``logreg_model_performance.csv``
+        zodat elk algoritme zijn eigen csv heeft.
+    """
 
     # 1. Laad en sorteer data
     df = pd.read_csv('processed_data.csv', parse_dates=['date'])

--- a/train_model_nested_cv.py
+++ b/train_model_nested_cv.py
@@ -11,8 +11,17 @@ from sklearn.metrics import (
     roc_auc_score,
 )
 
-def main(export_csv=True, csv_path="model_performance.csv"):
-    """Voert nested cross-validation uit en exporteert optioneel de resultaten."""
+def main(export_csv=True, csv_path="nestedcv_model_performance.csv"):
+    """Voert nested cross-validation uit en exporteert optioneel de resultaten.
+
+    Parameters
+    ----------
+    export_csv : bool, optional
+        Of de evaluatiemetrics naar ``csv_path`` weggeschreven moeten worden.
+    csv_path : str, optional
+        Pad van het csv-bestand. Standaard ``nestedcv_model_performance.csv``
+        zodat het resultaat van deze methode apart wordt opgeslagen.
+    """
 
     # 1. Data laden en sorteren op datum
     df = pd.read_csv('processed_data.csv', parse_dates=['date'])

--- a/train_model_stacking.py
+++ b/train_model_stacking.py
@@ -46,7 +46,7 @@ def _extract_clf(pipeline):
 
 
 def build_and_train_pipeline(export_csv: bool = True,
-                             csv_path: str = "model_performance.csv"):
+                             csv_path: str = "stacking_model_performance.csv"):
     """Train a stacking ensemble and optionally export metrics.
 
     Parameters
@@ -54,7 +54,9 @@ def build_and_train_pipeline(export_csv: bool = True,
     export_csv : bool, optional
         Whether to write the evaluation metrics to ``csv_path``.
     csv_path : str, optional
-        Path to save the CSV file with the model's performance.
+        Path to save the CSV file with the model's performance. By default this
+        is ``stacking_model_performance.csv`` so that each model writes to its
+        own dedicated file.
     """
 
     # 1. Load and sort the processed dataset

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -23,7 +23,7 @@ from sklearn.metrics import (
 )
 
 
-def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
+def build_and_train_pipeline(export_csv=True, csv_path="xgb_model_performance.csv"):
     """Train een XGBoost-model en retourneer het beste model samen met de
     optimale hyperparameters.
 
@@ -32,7 +32,9 @@ def build_and_train_pipeline(export_csv=True, csv_path="model_performance.csv"):
     export_csv : bool, optional
         Of de evaluatiemetrics naar ``csv_path`` weggeschreven moeten worden.
     csv_path : str, optional
-        Pad waar het CSV-bestand met prestaties wordt opgeslagen.
+        Pad waar het CSV-bestand met prestaties wordt opgeslagen. Standaard
+        wordt dit ``xgb_model_performance.csv`` zodat iedere trainingsscript
+        zijn eigen resultaten bijhoudt.
     """
 
     # 1. Laad de verwerkte data en sorteer chronologisch


### PR DESCRIPTION
## Summary
- save results of each training script to its own `<algo>_model_performance.csv`
- document separate metric files in README

## Testing
- `python -m py_compile train_model.py train_model_lgbm.py train_model_xgb.py train_model_catboost.py train_model_logreg.py train_model_stacking.py train_model_nested_cv.py`

------
https://chatgpt.com/codex/tasks/task_b_68488219cdfc8331a8bb9e88cb3ff9b5