### PR TITLE
Add standings-based features

### DIFF
--- a/train_model.py
+++ b/train_model.py
@@ -44,6 +44,8 @@ def build_and_train_pipeline(export_csv=True, csv_path="rf_model_performance.csv
         'month', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'finish_rate_prev5',
         'team_qual_gap',
+        'driver_points_prev', 'driver_rank_prev',
+        'constructor_points_prev', 'constructor_rank_prev',
 
         'grid_diff', 'Q3_diff',
 

--- a/train_model_catboost.py
+++ b/train_model_catboost.py
@@ -43,6 +43,8 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "catboost_
         'month', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'finish_rate_prev5',
         'team_qual_gap',
+        'driver_points_prev', 'driver_rank_prev',
+        'constructor_points_prev', 'constructor_rank_prev',
 
         # Overtakes-features
         'weighted_overtakes',

--- a/train_model_lgbm.py
+++ b/train_model_lgbm.py
@@ -47,6 +47,8 @@ def build_and_train_pipeline(export_csv=True, csv_path="lgbm_model_performance.c
         'month', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'finish_rate_prev5',
         'team_qual_gap',
+        'driver_points_prev', 'driver_rank_prev',
+        'constructor_points_prev', 'constructor_rank_prev',
 
         # Overtakes-features
         'weighted_overtakes',

--- a/train_model_logreg.py
+++ b/train_model_logreg.py
@@ -43,6 +43,8 @@ def build_and_train_pipeline(export_csv: bool = True, csv_path: str = "logreg_mo
         'grid_diff', 'Q3_diff',
         'finish_rate_prev5',
         'team_qual_gap',
+        'driver_points_prev', 'driver_rank_prev',
+        'constructor_points_prev', 'constructor_rank_prev',
 
         # Overtakes-features
         'weighted_overtakes',

--- a/train_model_nested_cv.py
+++ b/train_model_nested_cv.py
@@ -32,6 +32,8 @@ def main(export_csv=True, csv_path="nestedcv_model_performance.csv"):
         'month', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
         'finish_rate_prev5',
         'team_qual_gap',
+        'driver_points_prev', 'driver_rank_prev',
+        'constructor_points_prev', 'constructor_rank_prev',
 
         # Overtakes-features
         'weighted_overtakes',

--- a/train_model_stacking.py
+++ b/train_model_stacking.py
@@ -78,6 +78,8 @@ def build_and_train_pipeline(export_csv: bool = True,
         "Q3_diff",
         "finish_rate_prev5",
         'team_qual_gap',
+        'driver_points_prev', 'driver_rank_prev',
+        'constructor_points_prev', 'constructor_rank_prev',
 
         # Overtake features
         "weighted_overtakes",

--- a/train_model_xgb.py
+++ b/train_model_xgb.py
@@ -49,6 +49,8 @@ def build_and_train_pipeline(export_csv=True, csv_path="xgb_model_performance.cs
         'finish_rate_prev5',
         'grid_diff', 'Q3_diff',
         'team_qual_gap',
+        'driver_points_prev', 'driver_rank_prev',
+        'constructor_points_prev', 'constructor_rank_prev',
 
         # Overtakes-features
         'weighted_overtakes',


### PR DESCRIPTION
## Summary
- compute previous-season points and rank for drivers and constructors in `prepare_data.py`
- keep these columns in final dataset
- train scripts now include new features in `numeric_feats`

## Testing
- `python3 -m py_compile prepare_data.py train_model*.py`

------
https://chatgpt.com/codex/tasks/task_b_68492ec0a14483318d26548f41b4db37