### PR TITLE
Store threshold with model

### DIFF
--- a/export_model.py
+++ b/export_model.py
@@ -5,6 +5,8 @@ import joblib
 from sklearn.base import clone
 import pandas as pd
 
+from utils.threshold import find_best_threshold
+
 from train_model import build_and_train_pipeline as build_rf
 from train_model_lgbm import build_and_train_pipeline as build_lgbm
 from train_model_xgb import build_and_train_pipeline as build_xgb
@@ -32,16 +34,22 @@ def save_pipeline(algorithm: str = "rf"):
 
     print("Beste hyperparameters:", best_params)
 
-    # Fit opnieuw op volledige dataset met deze parameters
-    df = pd.read_csv('processed_data.csv')
-    X_full = df.drop(columns=['top3'])
-    y_full = df['top3']
+    # Fit opnieuw op volledige dataset en bepaal optimale drempel
+    df = pd.read_csv("processed_data.csv", parse_dates=["date"])
+    df = df.sort_values("date")
+    df["race_id"] = df["season"] * 100 + df["round"]
+    X_full = df.drop(columns=["top3"])
+    y_full = df["top3"]
+    groups = df["race_id"].values
+
+    threshold = find_best_threshold(pipeline, X_full, y_full, groups, metric="pr")
 
     final_model = clone(pipeline)
     final_model.fit(X_full, y_full)
 
-    joblib.dump(final_model, 'f1_top3_pipeline.joblib')
+    joblib.dump({"model": final_model, "threshold": threshold}, "f1_top3_pipeline.joblib")
     print("Pipeline opgeslagen als f1_top3_pipeline.joblib")
+    print(f"Optimale drempel: {threshold:.3f}")
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Exporteer een getrainde pipeline")

--- a/infer.py
+++ b/infer.py
@@ -61,8 +61,14 @@ def inference_for_date(cutoff_date):
     # 5. Select only the rows of the cutoff_date for testing
     df_test = df[df['date'] == cutoff_date].copy()
 
-    # 6. Load the serialized pipeline
-    pipeline = joblib.load('f1_top3_pipeline.joblib')
+    # 6. Load the serialized pipeline and stored threshold
+    saved_obj = joblib.load('f1_top3_pipeline.joblib')
+    if isinstance(saved_obj, dict):
+        pipeline = saved_obj.get('model')
+        threshold = saved_obj.get('threshold', 0.41)
+    else:
+        pipeline = saved_obj
+        threshold = 0.41
 
     # 7. Feature columns exactly as trained
     feature_cols = [
@@ -84,7 +90,7 @@ def inference_for_date(cutoff_date):
     # 8. Predict probabilities and apply threshold
     proba = pipeline.predict_proba(X_test)[:, 1]
     df_test['top3_proba'] = proba
-    df_test['top3_pred']  = proba >= 0.41
+    df_test['top3_pred']  = proba >= threshold
 
     # 9. Show top-3 unique drivers
     top3 = (

--- a/utils/threshold.py
+++ b/utils/threshold.py
@@ -1,0 +1,49 @@
+import numpy as np
+from sklearn.metrics import roc_curve, precision_recall_curve
+from sklearn.base import clone
+
+from .time_series import GroupTimeSeriesSplit
+
+
+def find_best_threshold(model, X, y, groups, metric="pr"):
+    """Estimate the optimal probability cutoff using cross-validated predictions.
+
+    Parameters
+    ----------
+    model : estimator object
+        The estimator pipeline. ``predict_proba`` must be implemented.
+    X : pandas.DataFrame or numpy.ndarray
+        Feature matrix used for fitting the estimator.
+    y : array-like
+        True target labels.
+    groups : array-like
+        Group labels for the ``GroupTimeSeriesSplit``.
+    metric : {"pr", "roc"}, optional
+        If ``"pr"`` (default), the threshold with the highest F1-score on the
+        precision-recall curve is returned. If ``"roc"``, the threshold that
+        maximises TPR - FPR on the ROC curve is returned.
+
+    Returns
+    -------
+    float
+        The selected probability threshold.
+    """
+
+    cv = GroupTimeSeriesSplit(n_splits=5)
+    proba = np.zeros(len(y))
+    for train_idx, test_idx in cv.split(X, y, groups):
+        clf = clone(model)
+        X_train, y_train = X.iloc[train_idx], y.iloc[train_idx]
+        clf.fit(X_train, y_train)
+        proba[test_idx] = clf.predict_proba(X.iloc[test_idx])[:, 1]
+
+    if metric == "roc":
+        fpr, tpr, thresholds = roc_curve(y, proba)
+        j_scores = tpr - fpr
+        best_idx = int(np.nanargmax(j_scores))
+        return float(thresholds[best_idx])
+
+    precision, recall, thresholds = precision_recall_curve(y, proba)
+    f1 = 2 * precision[:-1] * recall[:-1] / (precision[:-1] + recall[:-1] + 1e-9)
+    best_idx = int(np.nanargmax(f1))
+    return float(thresholds[best_idx])


### PR DESCRIPTION
## Summary
- add a helper to compute probability thresholds via cross‑validated predictions
- store the optimal threshold when exporting a pipeline
- load and apply the saved cutoff in `infer.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68492edc36a08331bbf9965ba3a99d39