### PR TITLE
Improve CatBoost pipeline

### DIFF
--- a/train_model_catboost.py
+++ b/train_model_catboost.py
@@ -42,8 +42,7 @@ def build_and_train_pipeline(export_csv: bool = True,
     # 2. Features en target
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'avg_finish_pos', 'avg_grid_pos', 'avg_const_finish',
-        'finish_rate_prev5',
+        'month', 'avg_finish_pos',
         'team_qual_gap',
 
         # Overtakes-features
@@ -53,6 +52,10 @@ def build_and_train_pipeline(export_csv: bool = True,
         'ewma_overtakes_per_lap',
         'ewma_weighted_overtakes_per_lap'
     ]
+    # ``avg_grid_pos``, ``avg_const_finish`` en ``finish_rate_prev5`` hadden
+    # een (bijna) nul of negatieve feature importance volgens
+    # ``feature_importances/catb_feature_importance.csv`` en zijn daarom
+    # verwijderd uit de trainingsfeatures.
     categorical_feats = ['circuit_country', 'circuit_city']
 
     X = df[numeric_feats + categorical_feats]
@@ -95,11 +98,14 @@ def build_and_train_pipeline(export_csv: bool = True,
     pos_weight = y_train.value_counts()[0] / y_train.value_counts()[1]
 
     param_grid = {
-        'clf__iterations': [200, 500],
-        'clf__depth': [4, 6, 8],
-        'clf__learning_rate': [0.03, 0.1],
-        'clf__l2_leaf_reg': [1, 3],
-        'clf__subsample': [0.8, 1.0],
+        'clf__iterations': [200, 500, 1000],
+        'clf__depth': [4, 6, 8, 10],
+        'clf__learning_rate': [0.01, 0.03, 0.1],
+        'clf__l2_leaf_reg': [1, 3, 5],
+        'clf__subsample': [0.7, 0.8, 1.0],
+        'clf__random_strength': [0, 1],
+        'clf__bagging_temperature': [0, 1, 2],
+        'clf__border_count': [64, 128],
         'clf__class_weights': [[1.0, pos_weight]],
     }
 


### PR DESCRIPTION
## Summary
- tune CatBoost by adding more hyperparameter options
- drop unused features with zero or negative importance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6849a5198378833184eedeb137b96ddb