### PR TITLE
Enhance features and tune CatBoost

### DIFF
--- a/prepare_data.py
+++ b/prepare_data.py
@@ -96,9 +96,44 @@ def main():
     )
     df_circ     = pd.read_csv(files['circuits'])
     df_sessions = pd.read_csv(files['sessions'], parse_dates=['date_start'])
-    df_weather  = pd.read_csv(files['weather'])
+    df_weather  = pd.read_csv(files['weather'], parse_dates=['date'])
     df_drvstand = pd.read_csv('jolpica_driverstandings.csv')
     df_constand = pd.read_csv('jolpica_constructorstandings.csv')
+
+    # --- Weather features -------------------------------------------------
+    location_to_circuit = {
+        'Austin': 'americas', 'Baku': 'baku', 'Barcelona': 'catalunya',
+        'Budapest': 'hungaroring', 'Imola': 'imola', 'Jeddah': 'jeddah',
+        'Las Vegas': 'vegas', 'Lusail': 'losail', 'Marina Bay': 'marina_bay',
+        'Melbourne': 'albert_park', 'Mexico City': 'rodriguez', 'Miami': 'miami',
+        'Monaco': 'monaco', 'Montréal': 'villeneuve', 'Monza': 'monza',
+        'Sakhir': 'bahrain', 'Shanghai': 'shanghai', 'Silverstone': 'silverstone',
+        'Spa-Francorchamps': 'spa', 'Spielberg': 'red_bull_ring',
+        'Suzuka': 'suzuka', 'São Paulo': 'interlagos', 'Yas Island': 'yas_marina',
+        'Zandvoort': 'zandvoort'
+    }
+
+    race_sessions = df_sessions[df_sessions['session_type'] == 'Race'].copy()
+    race_sessions['circuitId'] = race_sessions['location'].map(location_to_circuit)
+    race_sessions['gmt_offset'] = pd.to_timedelta(race_sessions['gmt_offset']).dt.total_seconds() / 3600
+
+    weather_rows = []
+    for _, row in race_sessions.iterrows():
+        sess = df_weather[df_weather['session_key'] == row['session_key']]
+        if sess.empty:
+            continue
+        window = sess[(sess['date'] >= row['date_start']) &
+                      (sess['date'] <= row['date_start'] + pd.Timedelta(minutes=30))]
+        if window.empty:
+            continue
+        agg = window[['air_temperature', 'track_temperature', 'humidity',
+                      'pressure', 'rainfall', 'wind_speed', 'wind_direction']].mean()
+        agg['season'] = row['year']
+        agg['circuitId'] = row['circuitId']
+        agg['gmt_offset'] = row['gmt_offset']
+        weather_rows.append(agg)
+
+    weather_df = pd.DataFrame(weather_rows)
 
     # Preload lap and pit stop data with caching
     unique_races = df_races[['season', 'round']].drop_duplicates()
@@ -205,6 +240,8 @@ def main():
     df['date']    = pd.to_datetime(df['date'])
     df['month']   = df['date'].dt.month
     df['Driver.dateOfBirth'] = pd.to_datetime(df['Driver.dateOfBirth'])
+    df['driver_age'] = (df['date'] - df['Driver.dateOfBirth']).dt.days / 365.25
+    df['weekday'] = df['date'].dt.weekday
 
     # 9. Impute kwalificatietijden per circuit
     # Sorteer op datum zodat we circuit-medians alleen uit voorgaande races
@@ -236,6 +273,14 @@ def main():
         'Location.lat':'circuit_lat', 'Location.long':'circuit_long',
         'Location.locality':'circuit_city', 'Location.country':'circuit_country'
     })
+
+    # Voeg samengevoegde weergegevens toe per race
+    df = df.merge(
+        weather_df,
+        on=['season', 'circuitId'],
+        how='left'
+    )
+    df['grid_temp_int'] = df['grid_position'] * df['track_temperature']
 
     # Rolling finish rate over previous 5 races per driver
     df = df.sort_values(['Driver.driverId', 'date'])
@@ -277,9 +322,7 @@ def main():
         on=['season','round','constructorId'], how='left'
     )
 
-    # (Weather merge removed)
-
-    # … na de existing rolling averages & weather-imputatie …
+    # … na de existing rolling averages & weer-imputatie …
 
     # 14a. Grid-difference feature
     df['grid_diff'] = df['avg_grid_pos'] - df['grid_position']
@@ -314,11 +357,9 @@ def main():
     ).fillna(0)
 
     drop_cols = [
-        'air_temperature', 'track_temperature', 'humidity', 'pressure',
-        'rainfall', 'wind_speed', 'wind_direction',
-        'constructor_points_prev', 'constructor_rank_prev', 'driver_age',
-        'grid_temp_int', 'driver_points_prev', 'driver_rank_prev',
-        'weekday', 'overtakes_count'
+        'constructor_points_prev', 'constructor_rank_prev',
+        'driver_points_prev', 'driver_rank_prev',
+        'overtakes_count'
     ]
     df.drop(columns=drop_cols, errors='ignore', inplace=True)
 

--- a/train_model_catboost.py
+++ b/train_model_catboost.py
@@ -42,20 +42,18 @@ def build_and_train_pipeline(export_csv: bool = True,
     # 2. Features en target
     numeric_feats = [
         'grid_position', 'Q1_sec', 'Q2_sec', 'Q3_sec',
-        'month', 'avg_finish_pos',
-        'team_qual_gap',
+        'month', 'avg_finish_pos', 'avg_grid_pos',
+        'avg_const_finish', 'finish_rate_prev5', 'team_qual_gap',
+        'grid_diff', 'Q3_diff', 'driver_age', 'weekday', 'gmt_offset',
+        'air_temperature', 'track_temperature', 'humidity', 'pressure',
+        'rainfall', 'wind_speed', 'wind_direction', 'grid_temp_int',
 
         # Overtakes-features
-        'weighted_overtakes',
-        'overtakes_per_lap',
-        'weighted_overtakes_per_lap',
-        'ewma_overtakes_per_lap',
+        'weighted_overtakes', 'overtakes_per_lap',
+        'weighted_overtakes_per_lap', 'ewma_overtakes_per_lap',
         'ewma_weighted_overtakes_per_lap'
     ]
-    # ``avg_grid_pos``, ``avg_const_finish`` en ``finish_rate_prev5`` hadden
-    # een (bijna) nul of negatieve feature importance volgens
-    # ``feature_importances/catb_feature_importance.csv`` en zijn daarom
-    # verwijderd uit de trainingsfeatures.
+
     categorical_feats = ['circuit_country', 'circuit_city']
 
     X = df[numeric_feats + categorical_feats]
@@ -98,14 +96,11 @@ def build_and_train_pipeline(export_csv: bool = True,
     pos_weight = y_train.value_counts()[0] / y_train.value_counts()[1]
 
     param_grid = {
-        'clf__iterations': [200, 500, 1000],
-        'clf__depth': [4, 6, 8, 10],
-        'clf__learning_rate': [0.01, 0.03, 0.1],
-        'clf__l2_leaf_reg': [1, 3, 5],
-        'clf__subsample': [0.7, 0.8, 1.0],
-        'clf__random_strength': [0, 1],
-        'clf__bagging_temperature': [0, 1, 2],
-        'clf__border_count': [64, 128],
+        'clf__iterations': [200, 400],
+        'clf__depth': [6, 8],
+        'clf__learning_rate': [0.05, 0.1],
+        'clf__l2_leaf_reg': [3],
+        'clf__subsample': [0.8, 1.0],
         'clf__class_weights': [[1.0, pos_weight]],
     }
 


### PR DESCRIPTION
## Summary
- aggregate OpenF1 weather data for each race
- compute driver age, weekday and weather-derived interaction features
- keep these new columns in the dataset
- extend training features and simplify CatBoost hyperparameter grid

## Testing
- `python -m py_compile prepare_data.py train_model_catboost.py`

------
https://chatgpt.com/codex/tasks/task_b_684a0957c70c8331b1078c924d4a04c5